### PR TITLE
Enable running specific test cases instead of all at once

### DIFF
--- a/nftest/NFTestRunner.py
+++ b/nftest/NFTestRunner.py
@@ -15,7 +15,7 @@ class NFTestRunner():
         self._global = _global
         self.cases = cases or []
 
-    def load_from_config(self, config_yaml:str):
+    def load_from_config(self, config_yaml:str, target_cases:List[str]):
         """ Load test info from config file. """
         validate_yaml(config_yaml)
         with open(config_yaml, 'rt') as handle:
@@ -31,6 +31,8 @@ class NFTestRunner():
                 del case['nf_config']
                 test_case = NFTestCase(**case)
                 test_case.combine_global(self._global)
+                if target_cases and not test_case.name in target_cases:
+                    continue
                 self.cases.append(test_case)
 
     def main(self):

--- a/nftest/common.py
+++ b/nftest/common.py
@@ -40,11 +40,11 @@ def calculate_checksum(path:Path) -> str:
 
 def find_config_yaml(args:argparse.Namespace):
     """ Find the test config yaml """
-    if args.CONFIG is None:
+    if args.config_file is None:
         if Path('./nftest.yaml').exists():
-            args.CONFIG = Path('./nftest.yaml')
+            args.config_file = Path('./nftest.yaml')
         elif Path('./nftest.yml').exists():
-            args.CONFIG = Path('./nftest.yml')
+            args.config_file = Path('./nftest.yml')
 
 def print_version_and_exist():
     """ print version and exist """


### PR DESCRIPTION
I found it useful sometimes to just run a specific test case with out changing all other test cases to `skip: true`. Here added an positional argument to accept the specific test cases to run. The test case specified must come from the config file (the `name` attribute of each test case). And now the main command is `nftest run`. 

Run all test cases:

```bash
nftest run
```

Run one specific test case:

```bash
nftest run test-case-1
```

Closes #15 