### PR TITLE
Stream NextFlow logs in realtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ---
 
 ## [Unreleased]
+### Changed
+- Wrap all NextFlow output with real-time line-by-line log statements
+- Add DEBUG lines about specific asserts
 
 ---
 

--- a/nftest/NFTestAssert.py
+++ b/nftest/NFTestAssert.py
@@ -54,7 +54,7 @@ class NFTestAssert():
             return func
         if self.method == 'md5':
             def func(actual, expect):
-                self._logger.debug(f"md5 {actual} {expect}")
+                self._logger.debug("md5 %s %s", actual, expect)
                 actual_value = calculate_checksum(actual)
                 expect_value = calculate_checksum(expect)
                 return actual_value == expect_value

--- a/nftest/NFTestAssert.py
+++ b/nftest/NFTestAssert.py
@@ -35,6 +35,7 @@ class NFTestAssert():
         assert_method = self.get_assert_method()
         try:
             assert assert_method(self.actual, self.expect)
+            self._logger.debug('Assertion passed')
         except AssertionError as error:
             self._logger.error('Assertion failed')
             self._logger.error('Actual: %s', self.actual)
@@ -47,11 +48,13 @@ class NFTestAssert():
         if self.script is not None:
             def func(actual, expect):
                 cmd = f"{self.script} {actual} {expect}"
+                self._logger.debug(cmd)
                 process_out = sp.run(cmd, shell=True, check=False)
                 return process_out.returncode == 0
             return func
         if self.method == 'md5':
             def func(actual, expect):
+                self._logger.debug(f"md5 {actual} {expect}")
                 actual_value = calculate_checksum(actual)
                 expect_value = calculate_checksum(expect)
                 return actual_value == expect_value

--- a/nftest/NFTestCase.py
+++ b/nftest/NFTestCase.py
@@ -1,16 +1,17 @@
 """ NF Test case """
 from __future__ import annotations
-import os
-import shutil
+
 import re
-import logging
+import selectors
+import shutil
+import subprocess as sp
+
+from logging import getLogger, INFO, ERROR
 from pathlib import Path
 from shlex import quote
-import selectors
-import subprocess as sp
 from subprocess import PIPE
-from logging import getLogger
 from typing import Callable, List, TYPE_CHECKING
+
 from nftest.common import remove_nextflow_logs
 from nftest.NFTestENV import NFTestENV
 
@@ -122,12 +123,12 @@ class NFTestCase():
                 selector.register(
                     fileobj=process.stdout,
                     events=selectors.EVENT_READ,
-                    data=logging.INFO
+                    data=INFO
                 )
                 selector.register(
                     fileobj=process.stderr,
                     events=selectors.EVENT_READ,
-                    data=logging.ERROR
+                    data=ERROR
                 )
 
                 while process.poll() is None:

--- a/nftest/NFTestCase.py
+++ b/nftest/NFTestCase.py
@@ -1,9 +1,12 @@
 """ NF Test case """
 from __future__ import annotations
+import os
 import shutil
 import re
+import logging
 from pathlib import Path
 from shlex import quote
+import selectors
 import subprocess as sp
 from subprocess import PIPE
 from logging import getLogger
@@ -29,6 +32,7 @@ class NFTestCase():
         """ Constructor """
         self._env = NFTestENV()
         self._logger = getLogger('NFTest')
+        self._nflogger = getLogger("NextFlow")
         self.name = name
         self.name_for_output = re.sub(r'[^a-zA-Z0-9_\-.]', '', self.name.replace(' ', '-'))
         self.message = message
@@ -107,22 +111,40 @@ class NFTestCase():
         """
         self._logger.info(' '.join(cmd.split()))
 
-        res = sp.run(cmd,
-            shell=True,
-            stdout=PIPE,
-            stderr=PIPE,
-            check=False,
-            universal_newlines=True,
-            capture_output=(not self.verbose))
+        with sp.Popen(cmd,
+                      shell=True,
+                      stdout=PIPE,
+                      stderr=PIPE,
+                      universal_newlines=True) as process:
 
-        self._logger.info(res.stdout)
-        if res.stderr.strip():
-            self._logger.error(res.stderr)
+            # Route stdout to INFO and stderr to ERROR in real-time
+            with selectors.DefaultSelector() as selector:
+                selector.register(
+                    fileobj=process.stdout,
+                    events=selectors.EVENT_READ,
+                    data=logging.INFO
+                )
+                selector.register(
+                    fileobj=process.stderr,
+                    events=selectors.EVENT_READ,
+                    data=logging.ERROR
+                )
 
-        return res
+                while process.poll() is None:
+                    events = selector.select()
+                    for key, _ in events:
+                        line = key.fileobj.readline()
+                        if line:
+                            # The only case in which this won't be true is when
+                            # the pipe is closed
+                            self._nflogger.log(
+                                level=key.data,
+                                msg=line.rstrip()
+                            )
 
+        return process
 
-    def combine_global(self, _global:NFTestGlobal) -> None:
+    def combine_global(self, _global: NFTestGlobal) -> None:
         """ Combine test case configs with the global configs. """
         if _global.nf_config:
             self.nf_configs.insert(0, _global.nf_config)

--- a/nftest/common.py
+++ b/nftest/common.py
@@ -70,7 +70,6 @@ def setup_loggers():
 
     # Make a stream handler with the requested verbosity
     stream_handler = logging.StreamHandler(sys.stdout)
-    # stream_handler.setFormatter(formatter)
     try:
         stream_handler.setLevel(logging._checkLevel(_env.NFT_LOG_LEVEL))
     except ValueError:

--- a/nftest/common.py
+++ b/nftest/common.py
@@ -71,7 +71,7 @@ def setup_loggers():
     # Make a stream handler with the requested verbosity
     stream_handler = logging.StreamHandler(sys.stdout)
     try:
-        stream_handler.setLevel(logging._checkLevel(_env.NFT_LOG_LEVEL))
+        stream_handler.setLevel(logging._checkLevel(_env.NFT_LOG_LEVEL)) # pylint: disable=W0212
     except ValueError:
         stream_handler.setLevel(logging.INFO)
 

--- a/nftest/common.py
+++ b/nftest/common.py
@@ -53,39 +53,31 @@ def print_version_and_exist():
     print(__version__, file=sys.stdout)
     sys.exit()
 
+
 def setup_loggers():
     """ Initialize loggers for both init and run """
-    _ = generate_logger('NFTest')
-    _ = generate_logger('NFTestInit')
-
-# pylint: disable=W0212
-def generate_logger(logger_name:str):
-    """ Generate program-specific logger """
-    _env = NFTestENV()
-    try:
-        log_level = logging._checkLevel(_env.NFT_LOG_LEVEL)
-    except ValueError:
-        log_level = logging._checkLevel('INFO')
-
-    logger = logging.getLogger(logger_name)
-    logger.setLevel(log_level)
-
-    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    # Always log times in UTC
     logging.Formatter.converter = time.gmtime
 
+    _env = NFTestENV()
+
+    # Make a file handler that accepts all logs
     try:
         file_handler = logging.FileHandler(_env.NFT_LOG)
+        file_handler.setLevel(logging.DEBUG)
     except (FileNotFoundError, PermissionError) as file_error:
         raise Exception(f'Unable to create log file: {_env.NFT_LOG}') from file_error
-    file_handler.setLevel(log_level)
 
+    # Make a stream handler with the requested verbosity
     stream_handler = logging.StreamHandler(sys.stdout)
-    stream_handler.setLevel(log_level)
+    # stream_handler.setFormatter(formatter)
+    try:
+        stream_handler.setLevel(logging._checkLevel(_env.NFT_LOG_LEVEL))
+    except ValueError:
+        stream_handler.setLevel(logging.INFO)
 
-    file_handler.setFormatter(formatter)
-    stream_handler.setFormatter(formatter)
-
-    logger.addHandler(file_handler)
-    logger.addHandler(stream_handler)
-
-    return logger
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+        handlers=(file_handler, stream_handler)
+    )


### PR DESCRIPTION
# Description
This uses the `selectors` module to poll for the NextFlow process's outputs so that they can be logged in real-time.

This has the additional bonus of ensuring that every line in the logfiles is prepended with a logging header; that makes parsing them after-the-fact _so_ much easier (for everything except tracebacks, but this doesn't make parsing those any harder).

Here is an example of the first and last 10 lines of an NFTest log file before these changes - literally all of the NextFlow job output is captured in one log record, which is recorded immediately before NFTest exits:
```
$ head log-nftest-20230831T203308Z.log && tail log-nftest-20230831T203308Z.log
2023-08-31 20:33:08,295 - NFTest - INFO - Beginning tests...
2023-08-31 20:33:08,296 - NFTest - INFO - A-mini-n2: None
2023-08-31 20:33:08,296 - NFTest - INFO - NXF_WORK=./test/work nextflow run ./main.nf -c /hot/user/nwiltsie/pipelines/pipeline-filter-RNAEditingSite/test/nftest.config -params-file ./test/A-mini-n2.yaml --output_dir /hot/software/pipeline/pipeline-filter-RNAEditingSite/Nextflow/development/unreleased/nwiltsie_standardize/A-mini-n2
2023-08-31 20:33:47,334 - NFTest - INFO - N E X T F L O W  ~  version 23.04.2
Launching `./main.nf` [magical_gilbert] DSL2 - revision: 7ffe311c28
==========================================
  filter-RNAEditingSite  P I P E L I N E
==========================================
Boutros Lab

[d2/c3f8fb] process > run_validate_PipeVal (3)       [100%] 4 of 4 ✔
[8a/ccf9de] process > run_selectPositions_REDItools  [100%] 1 of 1 ✔
[aa/02ecca] process > run_AnnotateRepeatMasker_RE... [100%] 1 of 1 ✔
[d6/2c6631] process > run_AnnotateGene_REDItools     [100%] 1 of 1 ✔
[dc/bdb552] process > run_FilterREDIportal_REDItools [100%] 1 of 1 ✔


2023-08-31 20:33:47,342 - NFTest - INFO -  [ succeed ]
2023-08-31 20:33:47,761 - NFTest - INFO - A-full: None
2023-08-31 20:33:47,761 - NFTest - INFO -  [ skipped ]
```

After these changes, this is the output that appears on stdout (hence why this is an sbatch log file):
```
$ head sbatch-nftest-20230831T224656Z.log && tail sbatch-nftest-20230831T224656Z.log
LOG: .env not found in /hot/user/nwiltsie/pipelines/pipeline-filter-RNAEditingSite.
LOG: .env not found in /mnt/exports/shared/home/nwiltsie.
WARN: unable to find .env. Default values will be used.
================================ NFTEST STARTS =================================
2023-08-31 22:47:00,312 - NFTest - INFO - Beginning tests...
2023-08-31 22:47:00,313 - NFTest - INFO - A-mini-n2: None
2023-08-31 22:47:00,313 - NFTest - INFO - NXF_WORK=./test/work nextflow run ./main.nf -c /hot/user/nwiltsie/pipelines/pipeline-filter-RNAEditingSite/test/nftest.config -params-file ./test/A-mini-n2.yaml --output_dir /hot/software/pipeline/pipeline-filter-RNAEditingSite/Nextflow/development/unreleased/nwiltsie_standardize/A-mini-n2
2023-08-31 22:47:03,222 - NextFlow - INFO - N E X T F L O W  ~  version 23.04.2
2023-08-31 22:47:05,948 - NextFlow - INFO - Launching `./main.nf` [dreamy_ekeblad] DSL2 - revision: 7ffe311c28
2023-08-31 22:47:09,603 - NextFlow - INFO - ==========================================
2023-08-31 22:47:38,641 - NextFlow - INFO - executor >  local (8)
2023-08-31 22:47:38,819 - NextFlow - INFO - [38/c5b7a1] process > run_validate_PipeVal (3)       [100%] 4 of 4 ✔
2023-08-31 22:47:38,819 - NextFlow - INFO - [de/6f5419] process > run_selectPositions_REDItools  [100%] 1 of 1 ✔
2023-08-31 22:47:38,819 - NextFlow - INFO - [d7/5cf1fb] process > run_AnnotateRepeatMasker_RE... [100%] 1 of 1 ✔
2023-08-31 22:47:38,819 - NextFlow - INFO - [b5/0c6420] process > run_AnnotateGene_REDItools     [100%] 1 of 1 ✔
2023-08-31 22:47:38,819 - NextFlow - INFO - [de/c7ffdc] process > run_FilterREDIportal_REDItools [100%] 1 of 1 ✔
2023-08-31 22:47:38,819 - NextFlow - INFO -
2023-08-31 22:47:38,897 - NFTest - INFO -  [ succeed ]
2023-08-31 22:47:39,293 - NFTest - INFO - A-full: None
2023-08-31 22:47:39,293 - NFTest - INFO -  [ skipped ]
```

The actual NFTest logfile has a few more DEBUG-level records that detail the specifics of the assert statements made for each test:

```
$ tail -n 15 log-nftest-20230831T224700Z.log
2023-08-31 22:47:38,819 - NextFlow - INFO - [38/c5b7a1] process > run_validate_PipeVal (3)       [100%] 4 of 4 ✔
2023-08-31 22:47:38,819 - NextFlow - INFO - [de/6f5419] process > run_selectPositions_REDItools  [100%] 1 of 1 ✔
2023-08-31 22:47:38,819 - NextFlow - INFO - [d7/5cf1fb] process > run_AnnotateRepeatMasker_RE... [100%] 1 of 1 ✔
2023-08-31 22:47:38,819 - NextFlow - INFO - [b5/0c6420] process > run_AnnotateGene_REDItools     [100%] 1 of 1 ✔
2023-08-31 22:47:38,819 - NextFlow - INFO - [de/c7ffdc] process > run_FilterREDIportal_REDItools [100%] 1 of 1 ✔
2023-08-31 22:47:38,819 - NextFlow - INFO -
2023-08-31 22:47:38,889 - NFTest - DEBUG - md5 /hot/software/pipeline/pipeline-filter-RNAEditingSite/Nextflow/development/unreleased/nwiltsie_standardize/A-mini-n2/filter-RNAEditingSite-1.0.0/CPCG0196-F1-A-mini-n2/REDItools-1.3/output/CPCG0196-F1-A-mini-n2_annotated.txt /hot/software/pipeline/pipeline-filter-RNAEditingSite/Nextflow/development/output/REDItools-1.3/output/CPCG0196-F1-A-mini-n2_annotated.txt
2023-08-31 22:47:38,891 - NFTest - DEBUG - Assertion passed
2023-08-31 22:47:38,892 - NFTest - DEBUG - md5 /hot/software/pipeline/pipeline-filter-RNAEditingSite/Nextflow/development/unreleased/nwiltsie_standardize/A-mini-n2/filter-RNAEditingSite-1.0.0/CPCG0196-F1-A-mini-n2/REDItools-1.3/output/CPCG0196-F1-A-mini-n2_candidates.txt /hot/software/pipeline/pipeline-filter-RNAEditingSite/Nextflow/development/output/REDItools-1.3/output/CPCG0196-F1-A-mini-n2_candidates.txt
2023-08-31 22:47:38,895 - NFTest - DEBUG - Assertion passed
2023-08-31 22:47:38,896 - NFTest - DEBUG - md5 /hot/software/pipeline/pipeline-filter-RNAEditingSite/Nextflow/development/unreleased/nwiltsie_standardize/A-mini-n2/filter-RNAEditingSite-1.0.0/CPCG0196-F1-A-mini-n2/REDItools-1.3/output/CPCG0196-F1-A-mini-n2_in_REDIportal.txt /hot/software/pipeline/pipeline-filter-RNAEditingSite/Nextflow/development/output/REDItools-1.3/output/CPCG0196-F1-A-mini-n2_in_REDIportal.txt
2023-08-31 22:47:38,897 - NFTest - DEBUG - Assertion passed
2023-08-31 22:47:38,897 - NFTest - INFO -  [ succeed ]
2023-08-31 22:47:39,293 - NFTest - INFO - A-full: None
2023-08-31 22:47:39,293 - NFTest - INFO -  [ skipped ]
```

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [x] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.


- [x] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

