### PR TITLE
Check that actual files are modified by pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Wrap all NextFlow output with real-time line-by-line log statements
 - Wrap custom comparison to log through NFTest logger
 - Add DEBUG lines about specific asserts
+- Assert that actual files are modified by pipelines
 
 ---
 

--- a/nftest/NFTestAssert.py
+++ b/nftest/NFTestAssert.py
@@ -13,10 +13,6 @@ from nftest.common import calculate_checksum
 from nftest.NFTestENV import NFTestENV
 
 
-class NotUpdatedError(Exception):
-    "Indicate that a file was not updated during a pipeline run."
-
-
 class NFTestAssert():
     """ Defines how nextflow test results are asserted. """
     def __init__(self, actual:str, expect:str, method:str='md5', script:str=None):
@@ -49,10 +45,8 @@ class NFTestAssert():
         )
         self._logger.debug("Test creation time: %s", self.startup_time)
         self._logger.debug("Actual mod time:    %s", file_mod_time)
-        if file_mod_time <= self.startup_time:
-            raise NotUpdatedError(
-                f"{str(self.actual)} was not modified by this pipeline"
-            )
+        assert file_mod_time > self.startup_time, \
+            f"{str(self.actual)} was not modified by this pipeline"
 
         assert_method = self.get_assert_method()
         try:

--- a/nftest/NFTestAssert.py
+++ b/nftest/NFTestAssert.py
@@ -15,7 +15,6 @@ from nftest.NFTestENV import NFTestENV
 
 class NotUpdatedError(Exception):
     "Indicate that a file was not updated during a pipeline run."
-    pass
 
 
 class NFTestAssert():

--- a/nftest/NFTestAssert.py
+++ b/nftest/NFTestAssert.py
@@ -41,8 +41,8 @@ class NFTestAssert():
         file_mod_time = datetime.datetime.fromtimestamp(
             Path(self.actual).stat().st_mtime,
             tz=datetime.timezone.utc
-
         )
+
         self._logger.debug("Test creation time: %s", self.startup_time)
         self._logger.debug("Actual mod time:    %s", file_mod_time)
         assert file_mod_time > self.startup_time, \

--- a/nftest/NFTestAssert.py
+++ b/nftest/NFTestAssert.py
@@ -14,6 +14,7 @@ from nftest.NFTestENV import NFTestENV
 
 
 class NotUpdatedError(Exception):
+    "Indicate that a file was not updated during a pipeline run."
     pass
 
 

--- a/nftest/NFTestCase.py
+++ b/nftest/NFTestCase.py
@@ -84,6 +84,8 @@ class NFTestCase():
             return
         for ass in self.asserts:
             try:
+                ass.assert_exists()
+                ass.assert_updated()
                 ass.assert_expected()
             except Exception as error:
                 self._logger.error(error.args)

--- a/test/unit/test_NFTestAssert.py
+++ b/test/unit/test_NFTestAssert.py
@@ -38,56 +38,66 @@ def test_get_assert_method_method(mock_assert):
 
     assert callable(mock_assert.get_assert_method(mock_assert()))
 
-@mock.patch('nftest.NFTestAssert.Path', autospec=True)
+
 @mock.patch('nftest.NFTestAssert.NFTestAssert', wraps=NFTestAssert)
-def test_assert_expected_fail(mock_assert, mock_path):
+def test_assert_exists(mock_assert):
+    '''Tests the functionality of the assert_exists method'''
+    # assert_exists() should raise an AssertionError if either or both of
+    # actual and expect do not exist.
+    # Tuples of (actual.exists(), expect.exists(), raises AssertionError)
+    cases = (
+        (True, True, False),
+        (False, True, True),
+        (True, False, True),
+        (False, False, True),
+    )
+
+    for case in cases:
+        mock_assert.return_value.actual.exists.return_value = case[0]
+        mock_assert.return_value.expect.exists.return_value = case[1]
+
+        if case[2]:
+            with pytest.raises(FileNotFoundError):
+                NFTestAssert.assert_exists(mock_assert())
+        else:
+            NFTestAssert.assert_exists(mock_assert())
+
+
+@mock.patch('nftest.NFTestAssert.NFTestAssert', wraps=NFTestAssert)
+def test_assert_updated(mock_assert):
     ''' Tests for failing assertion '''
     timestamp = 1689805542.4275217
 
-    test_path = '/A/path/for/tests'
-    mock_path.return_value.exists.return_value = True
-    mock_path.return_value.stat.return_value.st_mtime = timestamp
-    mock_assert.return_value.actual = test_path
-    mock_assert.return_value.expect = test_path
-    # Set the test start time to be before the timestamp
     mock_assert.return_value.startup_time = datetime.datetime.fromtimestamp(
-        timestamp-1,
+        timestamp,
         tz=datetime.timezone.utc
     )
-    mock_assert.return_value.get_assert_method = lambda: lambda x, y: False
-    mock_assert.return_value._logger.error = lambda x, y=None: None
-    mock_assert.return_value.mock_assert_expected = NFTestAssert.assert_expected
 
+    # Test expected to fail with a time before the start time
+    mock_assert.return_value.actual.stat.return_value.st_mtime = timestamp - 1
     with pytest.raises(AssertionError):
-        mock_assert().mock_assert_expected(mock_assert())
+        NFTestAssert.assert_updated(mock_assert())
 
-@mock.patch('nftest.NFTestAssert.Path', autospec=True)
+    # Test expected to fail with a time equal to the start time
+    mock_assert.return_value.actual.stat.return_value.st_mtime = timestamp
+    with pytest.raises(AssertionError):
+        NFTestAssert.assert_updated(mock_assert())
+
+    # Test expected to pass with a time after to the start time
+    mock_assert.return_value.actual.stat.return_value.st_mtime = timestamp + 1
+    NFTestAssert.assert_updated(mock_assert())
+
+
 @mock.patch('nftest.NFTestAssert.NFTestAssert', wraps=NFTestAssert)
-def test_assert_expected_pass(mock_assert, mock_path):
+def test_assert_expected(mock_assert):
     ''' Tests for passing assertion '''
-    timestamp = 1689805542.4275217
-    test_path = '/A/path/for/tests'
-    mock_path.return_value.exists.return_value = True
-    mock_path.return_value.stat.return_value.st_mtime = timestamp
-    mock_assert.return_value.actual = test_path
-    mock_assert.return_value.expect = test_path
-    # Set the test start time to be before the timestamp
-    mock_assert.return_value.startup_time = datetime.datetime.fromtimestamp(
-        timestamp-1,
-        tz=datetime.timezone.utc
-    )
-    mock_assert.return_value.get_assert_method = lambda: lambda x, y: True
     mock_assert.return_value._logger.error = lambda x, y=None: None
-    # Mock the method being tested since pytest doesn't allow attributes starting with "assert"
-    mock_assert.return_value.mock_assert_expected = NFTestAssert.assert_expected
 
-    assert mock_assert().mock_assert_expected(mock_assert()) is None
+    # A passing test should not raise an error
+    mock_assert.return_value.get_assert_method = lambda: lambda x, y: True
+    NFTestAssert.assert_expected(mock_assert())
 
-    # Set the test start time to be after the timestamp
-    mock_assert.return_value.startup_time = datetime.datetime.fromtimestamp(
-        timestamp+1,
-        tz=datetime.timezone.utc
-    )
-
+    # A failing test should raise an error
+    mock_assert.return_value.get_assert_method = lambda: lambda x, y: False
     with pytest.raises(AssertionError):
-        mock_assert().mock_assert_expected(mock_assert())
+        NFTestAssert.assert_expected(mock_assert())


### PR DESCRIPTION
# Description
This adds a check that the `actual` files are have a modification time after the creation of their associated `NFTestAssert`. Here's an example from https://github.com/uclahs-cds/pipeline-filter-RNAEditingSite/pull/13 showing how I was comparing to an existing-but-incorrect file:

```
2023-09-26 22:07:30,262 - NextFlow - INFO - All positions: 74
2023-09-26 22:07:30,262 - NextFlow - INFO - Positions filtered in: 0
2023-09-26 22:07:30,396 - NextFlow - INFO - Positions filtered out: 74
2023-09-26 22:07:30,396 - NextFlow - INFO -
2023-09-26 22:07:30,397 - NextFlow - INFO -
2023-09-26 22:07:30,476 - NFTest - DEBUG - Test creation time: 2023-09-26 22:07:00.532961+00:00
2023-09-26 22:07:30,476 - NFTest - DEBUG - Actual mod time:    2023-09-01 21:21:11.930667+00:00
2023-09-26 22:07:30,476 - NFTest - ERROR - ('/hot/software/pipeline/pipeline-filter-RNAEditingSite/Nextflow/development/unreleased/nwiltsie_standardize/A-mini-n2/filter-RNAEditingSite-1.0.0/CPCG0196-F1-A-mini-n2/REDItools-1.3/output/CPCG0196-F1-A-mini-n2_annotated.txt was not modified by this pipeline',)
2023-09-26 22:07:30,476 - NFTest - ERROR -  [ failed ]
```

Here's an example where I _did_ have that `-rc` appended to the pipeline version:
```
2023-09-26 22:04:09,510 - NextFlow - INFO - All positions: 74
2023-09-26 22:04:09,510 - NextFlow - INFO - Positions filtered in: 0
2023-09-26 22:04:09,510 - NextFlow - INFO - Positions filtered out: 74
2023-09-26 22:04:09,510 - NextFlow - INFO -
2023-09-26 22:04:09,510 - NextFlow - INFO -
2023-09-26 22:04:09,559 - NFTest - DEBUG - Test creation time: 2023-09-26 22:03:41.858707+00:00
2023-09-26 22:04:09,560 - NFTest - DEBUG - Actual mod time:    2023-09-26 22:04:00.621141+00:00
2023-09-26 22:04:09,560 - NFTest - DEBUG - md5 /hot/software/pipeline/pipeline-filter-RNAEditingSite/Nextflow/development/unreleased/nwiltsie_standardize/A-mini-n2/filter-RNAEditingSite-1.0.0-rc/CPCG0196-F1-A-mini-n2/REDItools-1.3/output/CPCG0196-F1-A-mini-n2_annotated.txt /hot/software/pipeline/pipeline-filter-RNAEditingSite/Nextflow/development/output/REDItools-1.3/output/CPCG0196-F1-A-mini-n2_annotated.txt
2023-09-26 22:04:09,561 - NFTest - DEBUG - Assertion passed
```

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [x] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.


- [x] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

