### PR TITLE
Print usage when no argument is given, exit with aggregated test status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ---
 
 ## [Unreleased]
+### Changed
+- Make `nftest run` exit with the number of failed tests
+
+### Fixed
+- Make `nftest` with no arguments print usage and exit
 
 ---
 

--- a/nftest/NFTestCase.py
+++ b/nftest/NFTestCase.py
@@ -60,16 +60,19 @@ class NFTestCase():
         return asserts
 
     # pylint: disable=E0213
-    def test_wrapper(func:Callable):
+    def test_wrapper(func: Callable):
         """ Wrap tests with additional logging and cleaning. """
         def wrapper(self):
             # pylint: disable=E1102
             self.print_prolog()
-            func(self)
+            result = func(self)
             if self.remove_temp:
                 shutil.rmtree(self.temp_dir, ignore_errors=True)
             if self.clean_logs:
                 remove_nextflow_logs()
+
+            return result
+
         return wrapper
 
     @test_wrapper

--- a/nftest/NFTestCase.py
+++ b/nftest/NFTestCase.py
@@ -73,15 +73,15 @@ class NFTestCase():
         return wrapper
 
     @test_wrapper
-    def test(self):
+    def test(self) -> bool:
         """ Run test cases. """
         if self.skip:
             self._logger.info(' [ skipped ]')
-            return
+            return True
         res = self.submit()
         if res.returncode != 0:
             self._logger.error(' [ failed ]')
-            return
+            return False
         for ass in self.asserts:
             try:
                 ass.assert_exists()
@@ -92,6 +92,7 @@ class NFTestCase():
                 self._logger.error(' [ failed ]')
                 raise error
         self._logger.info(' [ succeed ]')
+        return True
 
     def submit(self) -> sp.CompletedProcess:
         """ Submit a nextflow run """

--- a/nftest/NFTestRunner.py
+++ b/nftest/NFTestRunner.py
@@ -45,12 +45,18 @@ class NFTestRunner():
     def main(self):
         """ Main entrance """
         self.print_prolog()
+
+        failure_count = 0
+
         for case in self.cases:
             try:
-                case.test()
+                if not case.test():
+                    failure_count += 1
             except AssertionError:
                 # In case of failed test case, continue with other cases
-                continue
+                failure_count += 1
+
+        return failure_count
 
     def print_prolog(self):
         """ Print prolog """

--- a/nftest/__main__.py
+++ b/nftest/__main__.py
@@ -79,7 +79,7 @@ def run(args):
     setup_loggers()
     runner = NFTestRunner()
     runner.load_from_config(args.config_file, args.TEST_CASES)
-    runner.main()
+    sys.exit(runner.main())
 
 def init(_):
     """ Set up nftest """

--- a/nftest/__main__.py
+++ b/nftest/__main__.py
@@ -1,6 +1,7 @@
 """ Test NF-pipelines """
 from __future__ import annotations
 import argparse
+import sys
 from logging import getLogger
 from pathlib import Path
 import shutil
@@ -25,7 +26,17 @@ def parse_args() -> argparse.Namespace:
     subparsers = parser.add_subparsers(dest='command')
     add_subparser_init(subparsers)
     add_subparser_run(subparsers)
-    return parser.parse_args()
+
+    args = parser.parse_args()
+
+    if args.version:
+        print_version_and_exist()
+
+    if not hasattr(args, "func"):
+        parser.print_usage()
+        sys.exit(1)
+
+    return args
 
 # pylint: disable=W0212
 def add_subparser_init(subparsers:argparse._SubParsersAction):
@@ -112,9 +123,6 @@ def init(_):
 def main():
     """ main entrance """
     args = parse_args()
-
-    if args.version:
-        print_version_and_exist()
 
     args.func(args)
 


### PR DESCRIPTION
# Description
This fixes two interface annoyances with NFTest.

First, calling `nftest` with no arguments throws an error [due to this line](https://github.com/uclahs-cds/tool-NFTest/blob/d096b96ef49d0a9b41e48f12feb4b05bd6b15fbb/nftest/__main__.py#L119):
```console
$ nftest
Traceback (most recent call last):
  File "/hot/code/nwiltsie/venvs/nftest-dev/bin/nftest", line 8, in <module>
    sys.exit(main())
  File "/hot/code/nwiltsie/tools/tool-NFTest/nftest/__main__.py", line 119, in main
    args.func(args)
AttributeError: 'Namespace' object has no attribute 'func'
```

03f49e1 changes that behavior to print the usage and exit with code `1`:

```console
$ nftest
usage: nftest [-h] [-V] {init,run} ...
$ echo $?
1
```

Second, as per #53 `nftest run` always exits with code `0`, regardless of any test failures. After c526bf6 it now exits with the number of tests that failed to run (i.e. Nextflow threw an error like "ERROR ~ Unable to parse config file") or failed any assertions.

```console
$ nftest run
...
2024-01-03 18:45:18,165 - NFTest - INFO - Beginning tests...
...
2024-01-03 18:45:27,289 - NFTest - ERROR -  [ failed ]
...
2024-01-03 18:45:35,986 - NFTest - ERROR -  [ failed ]
...
2024-01-03 18:45:45,400 - NFTest - ERROR -  [ failed ]
$ echo $?
3
```

### Closes #53 

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [x] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.


- [x] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.