### PR TITLE
Use `shell=False` for subprocess calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 ### Changed
 - Make `nftest run` exit with the number of failed tests
+- Use `shell=False` for subprocess
 
 ### Fixed
 - Make `nftest` with no arguments print usage and exit

--- a/nftest/NFTestAssert.py
+++ b/nftest/NFTestAssert.py
@@ -71,10 +71,9 @@ class NFTestAssert():
         # pylint: disable=E0102
         if self.script is not None:
             def func(actual, expect):
-                cmd = f"{self.script} {actual} {expect}"
-                self._logger.debug(cmd)
+                cmd = [self.script, actual, expect]
+                self._logger.debug(sp.list2cmdline(cmd))
                 with sp.Popen(cmd,
-                              shell=True,
                               stdout=PIPE,
                               stderr=PIPE,
                               universal_newlines=True) as process:
@@ -96,8 +95,8 @@ class NFTestAssert():
                             for key, _ in events:
                                 line = key.fileobj.readline()
                                 if line:
-                                    # The only case in which this won't be true is when
-                                    # the pipe is closed
+                                    # The only case in which this won't be true
+                                    # is when the pipe is closed
                                     self._logger.log(
                                         level=key.data,
                                         msg=line.rstrip()

--- a/nftest/NFTestAssert.py
+++ b/nftest/NFTestAssert.py
@@ -3,12 +3,12 @@ import datetime
 import errno
 import os
 import selectors
-import subprocess as sp
-from subprocess import PIPE
+import subprocess
 from typing import Callable
 from logging import getLogger, DEBUG, ERROR
 
-from nftest.common import calculate_checksum, resolve_single_path
+from nftest.common import calculate_checksum, resolve_single_path, \
+    popen_with_logger
 from nftest.NFTestENV import NFTestENV
 
 
@@ -72,36 +72,11 @@ class NFTestAssert():
         if self.script is not None:
             def func(actual, expect):
                 cmd = [self.script, actual, expect]
-                self._logger.debug(sp.list2cmdline(cmd))
-                with sp.Popen(cmd,
-                              stdout=PIPE,
-                              stderr=PIPE,
-                              universal_newlines=True) as process:
-                    # Route stdout to INFO and stderr to ERROR in real-time
-                    with selectors.DefaultSelector() as selector:
-                        selector.register(
-                            fileobj=process.stdout,
-                            events=selectors.EVENT_READ,
-                            data=DEBUG
-                        )
-                        selector.register(
-                            fileobj=process.stderr,
-                            events=selectors.EVENT_READ,
-                            data=ERROR
-                        )
+                self._logger.debug(subprocess.list2cmdline(cmd))
 
-                        while process.poll() is None:
-                            events = selector.select()
-                            for key, _ in events:
-                                line = key.fileobj.readline()
-                                if line:
-                                    # The only case in which this won't be true
-                                    # is when the pipe is closed
-                                    self._logger.log(
-                                        level=key.data,
-                                        msg=line.rstrip()
-                                    )
+                process = popen_with_logger(cmd, logger=self._logger)
                 return process.returncode == 0
+
             return func
         if self.method == 'md5':
             def func(actual, expect):

--- a/nftest/NFTestAssert.py
+++ b/nftest/NFTestAssert.py
@@ -2,10 +2,9 @@
 import datetime
 import errno
 import os
-import selectors
 import subprocess
 from typing import Callable
-from logging import getLogger, DEBUG, ERROR
+from logging import getLogger, DEBUG
 
 from nftest.common import calculate_checksum, resolve_single_path, \
     popen_with_logger
@@ -74,7 +73,11 @@ class NFTestAssert():
                 cmd = [self.script, actual, expect]
                 self._logger.debug(subprocess.list2cmdline(cmd))
 
-                process = popen_with_logger(cmd, logger=self._logger)
+                process = popen_with_logger(
+                    cmd,
+                    logger=self._logger,
+                    stdout_level=DEBUG
+                )
                 return process.returncode == 0
 
             return func

--- a/nftest/NFTestCase.py
+++ b/nftest/NFTestCase.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import os
 import re
-import selectors
 import shutil
 import subprocess as sp
 

--- a/nftest/NFTestCase.py
+++ b/nftest/NFTestCase.py
@@ -7,10 +7,9 @@ import selectors
 import shutil
 import subprocess as sp
 
-from logging import getLogger, INFO, ERROR
+from logging import getLogger
 from pathlib import Path
 from shlex import quote
-from subprocess import PIPE
 from typing import Callable, List, TYPE_CHECKING
 
 from nftest.common import remove_nextflow_logs, popen_with_logger

--- a/nftest/common.py
+++ b/nftest/common.py
@@ -1,13 +1,17 @@
 """ Common functions """
 import argparse
-import hashlib
 import glob
-import os
+import hashlib
 import logging
-from pathlib import Path
+import os
+import selectors
 import shutil
+import subprocess
 import sys
 import time
+
+from pathlib import Path
+
 from nftest import __version__
 from nftest.NFTestENV import NFTestENV
 
@@ -89,3 +93,49 @@ def setup_loggers():
         format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
         handlers=(file_handler, stream_handler)
     )
+
+
+def popen_with_logger(*args, logger=None, **kwargs) -> subprocess.CompletedProcess:
+    """
+    Run a subprocess and stream the console outputs to a logger.
+    """
+    for badarg in ("stdout", "stderr", "universal_newlines"):
+        if badarg in kwargs:
+            raise ValueError(f"Argument {badarg} is not allowed")
+
+    if logger is None:
+        raise ValueError("A logger must be supplied!")
+
+    kwargs.update({
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "universal_newlines": True
+    })
+
+    with subprocess.Popen(*args, **kwargs) as process:
+        # Route stdout to INFO and stderr to ERROR in real-time
+        with selectors.DefaultSelector() as selector:
+            selector.register(
+                fileobj=process.stdout,
+                events=selectors.EVENT_READ,
+                data=logging.INFO
+            )
+            selector.register(
+                fileobj=process.stderr,
+                events=selectors.EVENT_READ,
+                data=logging.ERROR
+            )
+
+            while process.poll() is None:
+                events = selector.select()
+                for key, _ in events:
+                    line = key.fileobj.readline()
+                    if line:
+                        # The only case in which this won't be true is when
+                        # the pipe is closed
+                        logger.log(
+                            level=key.data,
+                            msg=line.rstrip()
+                        )
+
+    return process

--- a/nftest/common.py
+++ b/nftest/common.py
@@ -95,7 +95,11 @@ def setup_loggers():
     )
 
 
-def popen_with_logger(*args, logger=None, **kwargs) -> subprocess.CompletedProcess:
+def popen_with_logger(*args,
+                      logger=None,
+                      stdout_level=logging.INFO,
+                      stderr_level=logging.ERROR,
+                      **kwargs) -> subprocess.CompletedProcess:
     """
     Run a subprocess and stream the console outputs to a logger.
     """
@@ -118,12 +122,12 @@ def popen_with_logger(*args, logger=None, **kwargs) -> subprocess.CompletedProce
             selector.register(
                 fileobj=process.stdout,
                 events=selectors.EVENT_READ,
-                data=logging.INFO
+                data=stdout_level
             )
             selector.register(
                 fileobj=process.stderr,
                 events=selectors.EVENT_READ,
-                data=logging.ERROR
+                data=stderr_level
             )
 
             while process.poll() is None:

--- a/test/unit/test_NFTestCase.py
+++ b/test/unit/test_NFTestCase.py
@@ -24,8 +24,8 @@ def test_combine_global(mock_case):
     assert case.temp_dir == test_temp_directory
     assert case.clean_logs == test_clean_logs
 
-@mock.patch('nftest.NFTestCase.selectors')
-@mock.patch('nftest.NFTestCase.sp.Popen')
+@mock.patch('nftest.common.selectors')
+@mock.patch('nftest.common.subprocess.Popen')
 @mock.patch('nftest.NFTestCase.NFTestCase', wraps=NFTestCase)
 def test_submit(mock_case, mock_sp, mock_selectors):
     ''' Tests for submission step '''


### PR DESCRIPTION
# Description
This PR switches both instances of `subprocess.Popen` (launching Nextflow and launching the custom assert script) to use `shell=False`.

[It's generally recommended](https://docs.python.org/3/library/subprocess.html#security-considerations) to use `shell=False` to avoid any potential [shell injections](https://en.wikipedia.org/wiki/Code_injection#Shell_injection).

One subtle change associated with this is that we have to set the `NXF_WORK` environment variable via the `env` argument of `subprocess.Popen`, rather than embedding it in the command string. `env` is the complete set of environment variables so we have to merge the current process's environment with our changes (`{**os.environ, **envmod}`).

I tested this by adding a custom comparison script to pipeline-recalibrate-BAM's [NFTest suite](https://github.com/uclahs-cds/pipeline-recalibrate-BAM/blob/a1be4a8bf2d8b3e40cf64957112e9cbfd93bc6e2/nftest.yml):

```diff
$ git diff nftest.yml
diff --git a/nftest.yml b/nftest.yml
index afb3919..f577708 100644
--- a/nftest.yml
+++ b/nftest.yml
@@ -14,13 +14,13 @@ cases:
     asserts:
       - actual: recalibrate-BAM-1.0.0-rc.4/TWGSAMIN000001/GATK-4.2.4.1/output/BWA-MEM2-2.2.1_GATK-4.2.4.1_A-mini_S2-v1.1.5.bam
         expect: /hot/software/pipeline/pipeline-recalibrate-BAM/Nextflow/development/output/BWA-MEM2-2.2.1_GATK-4.2.4.1_A-mini_S2-v1.1.5.bam
-        method: md5
+        script: ./compare.py
       - actual: recalibrate-BAM-1.0.0-rc.4/TWGSAMIN000001/GATK-4.2.4.1/output/BWA-MEM2-2.2.1_GATK-4.2.4.1_A-mini_S2-v1.1.5.bam.bai
         expect: /hot/software/pipeline/pipeline-recalibrate-BAM/Nextflow/development/output/BWA-MEM2-2.2.1_GATK-4.2.4.1_A-mini_S2-v1.1.5.bam.bai
-        method: md5
+        script: ./compare.py
       - actual: recalibrate-BAM-1.0.0-rc.4/TWGSAMIN000001/GATK-4.2.4.1/output/BWA-MEM2-2.2.1_GATK-4.2.4.1_A-mini_S2-v1.1.5.bam.sha512
         expect: /hot/software/pipeline/pipeline-recalibrate-BAM/Nextflow/development/output/BWA-MEM2-2.2.1_GATK-4.2.4.1_A-mini_S2-v1.1.5.bam.sha512
-        method: md5
+        script: ./compare.py
       - actual: recalibrate-BAM-1.0.0-rc.4/TWGSAMIN000001/GATK-4.2.4.1/output/BWA-MEM2-2.2.1_GATK-4.2.4.1_A-mini_S2-v1.1.5.bam.bai.sha512
         expect: /hot/software/pipeline/pipeline-recalibrate-BAM/Nextflow/development/output/BWA-MEM2-2.2.1_GATK-4.2.4.1_A-mini_S2-v1.1.5.bam.bai.sha512
-        method: md5
+        script: ./compare.py
```

The NFTest log file (`/hot/software/pipeline/pipeline-recalibrate-BAM/Nextflow/development/unreleased/main/log-nftest-20240111T231156Z.log`) shows that both the Nextflow invocation...

```
2024-01-11 23:11:56,768 - NFTest - INFO - NXF_WORK=./test/work nextflow run ./main.nf -c /hot/code/nwiltsie/pipelines/pipeline-recalibrate-BAM/test/nftest.config -params-file ./test/single.yaml --output_dir /hot/software/pipeline/pipeline-recalibrate-BAM/Nextflow/development/unreleased/main/A-mini-n2
```

... and the comparison invocations...

```
2024-01-11 23:25:25,339 - NFTest - DEBUG - ./compare.py /hot/software/pipeline/pipeline-recalibrate-BAM/Nextflow/development/unreleased/main/A-mini-n2/recalibrate-BAM-1.0.0-rc.4/TWGSAMIN000001/GATK-4.2.4.1/output/BWA-MEM2-2.2.1_GATK-4.2.4.1_A-mini_S2-v1.1.5.bam /hot/software/pipeline/pipeline-recalibrate-BAM/Nextflow/development/output/BWA-MEM2-2.2.1_GATK-4.2.4.1_A-mini_S2-v1.1.5.bam
2024-01-11 23:25:26,298 - NFTest - DEBUG - /hot/software/pipeline/pipeline-recalibrate-BAM/Nextflow/development/unreleased/main/A-mini-n2/recalibrate-BAM-1.0.0-rc.4/TWGSAMIN000001/GATK-4.2.4.1/output/BWA-MEM2-2.2.1_GATK-4.2.4.1_A-mini_S2-v1.1.5.bam
2024-01-11 23:25:26,322 - NFTest - DEBUG - /hot/software/pipeline/pipeline-recalibrate-BAM/Nextflow/development/output/BWA-MEM2-2.2.1_GATK-4.2.4.1_A-mini_S2-v1.1.5.bam
2024-01-11 23:25:26,322 - NFTest - DEBUG - Assertion passed
```

... are well-formatted and function appropriately (`compare.py` just prints the inputs and exits with `0`).

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [x] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.


- [x] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

