### PR TITLE
Reference checksum validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ---
 
 ## [Unreleased]
+### Added
+- Validation of reference files
+
 ### Changed
 - Make `nftest run` exit with the number of failed tests
 - Use `shell=False` for subprocess

--- a/nftest/NFTestCase.py
+++ b/nftest/NFTestCase.py
@@ -9,7 +9,7 @@ import subprocess as sp
 from logging import getLogger
 from pathlib import Path
 from shlex import quote
-from typing import Callable, List, TYPE_CHECKING
+from typing import Callable, List, TYPE_CHECKING, Tuple
 
 from nftest.common import remove_nextflow_logs, popen_with_logger
 from nftest.NFTestENV import NFTestENV
@@ -25,6 +25,7 @@ class NFTestCase():
     # pylint: disable=R0913
     def __init__(self, name:str=None, message:str=None, nf_script:str=None,
             nf_configs:List[str]=None, profiles:List[str]=None, params_file:str=None,
+            reference_params:List[Tuple[str,str]]=None,
             output_directory_param_name:str='output_dir',
             asserts:List[NFTestAssert]=None, temp_dir:str=None,
             remove_temp:bool=None, clean_logs:bool=None,
@@ -38,6 +39,7 @@ class NFTestCase():
         self.message = message
         self.nf_script = nf_script
         self.nf_configs = nf_configs or []
+        self.reference_params = reference_params or []
         self.profiles = profiles or []
         self.params_file = params_file
         self.output_directory_param_name = output_directory_param_name
@@ -110,6 +112,9 @@ class NFTestCase():
 
         if self.params_file:
             nextflow_command.extend(["-params-file", self.params_file])
+
+        for param_name, path in self.reference_params:
+            nextflow_command.extend([f"--{param_name}", path])
 
         nextflow_command.extend([
             f"--{self.output_directory_param_name}",

--- a/nftest/NFTestRunner.py
+++ b/nftest/NFTestRunner.py
@@ -7,7 +7,7 @@ from nftest.NFTestGlobal import NFTestGlobal
 from nftest.NFTestAssert import NFTestAssert
 from nftest.NFTestCase import NFTestCase
 from nftest.NFTestENV import NFTestENV
-from nftest.common import validate_yaml
+from nftest.common import validate_yaml, validate_reference
 
 class NFTestRunner():
     """ This holds all test cases and global settings from a single yaml file.
@@ -33,6 +33,9 @@ class NFTestRunner():
                     asserts = []
                 case['asserts'] = asserts
                 case['nf_configs'] = [case.pop('nf_config')] if case.get('nf_config', None) else []
+                if 'reference_files' in case:
+                    case['reference_params'] = [validate_reference(**reference_file)
+                        for reference_file in case.pop('reference_files')]
                 test_case = NFTestCase(**case)
                 test_case.combine_global(self._global)
                 if target_cases:

--- a/nftest/common.py
+++ b/nftest/common.py
@@ -1,6 +1,7 @@
 """ Common functions """
 import argparse
 import re
+from typing import Tuple
 import glob
 import hashlib
 import logging
@@ -58,7 +59,7 @@ def validate_reference(
     reference_parameter_name:str,
     reference_parameter_path:str,
     reference_checksum:str,
-    reference_checksum_type:str) -> tuple[str, str]:
+    reference_checksum_type:str) -> Tuple[str, str]:
     """ Validate reference file and checksum """
     if not re.match(r'[a-zA-Z0-9_\-.]+$', reference_parameter_name):
         raise ValueError(f'Reference parameter name: `{reference_parameter_name}` is invalid. '

--- a/nftest/common.py
+++ b/nftest/common.py
@@ -1,5 +1,6 @@
 """ Common functions """
 import argparse
+import re
 import glob
 import hashlib
 import logging
@@ -52,6 +53,27 @@ def calculate_checksum(path:Path) -> str:
             sum_val.update(byte_block)
     sum_val = sum_val.hexdigest()
     return sum_val
+
+def validate_reference(
+    reference_parameter_name:str,
+    reference_parameter_path:str,
+    reference_checksum:str,
+    reference_checksum_type:str) -> tuple[str, str]:
+    """ Validate reference file and checksum """
+    if not re.match(r'[a-zA-Z0-9_\-.]+$', reference_parameter_name):
+        raise ValueError(f'Reference parameter name: `{reference_parameter_name}` is invalid. '
+            f'Please use only alphanumeric, _, -, and . characters in parameter names.')
+
+    _logger = logging.getLogger("NFTest")
+
+    actual_checksum = calculate_checksum(Path(reference_parameter_path))
+
+    if actual_checksum != reference_checksum:
+        _logger.warning(f'Checksum for reference file: {reference_parameter_name}'
+            f'={reference_parameter_path} - `{actual_checksum}` '
+            f'does not match expected checksum of `{reference_checksum}`')
+
+    return (reference_parameter_name, reference_parameter_path)
 
 def find_config_yaml(args:argparse.Namespace):
     """ Find the test config yaml """

--- a/nftest/common.py
+++ b/nftest/common.py
@@ -70,9 +70,12 @@ def validate_reference(
     actual_checksum = calculate_checksum(Path(reference_parameter_path))
 
     if actual_checksum != reference_checksum:
-        _logger.warning(f'Checksum for reference file: {reference_parameter_name}'
-            f'={reference_parameter_path} - `{actual_checksum}` '
-            f'does not match expected checksum of `{reference_checksum}`')
+        _logger.warning('Checksum for reference file: %s'
+            '=%s - `%s` does not match expected checksum of `%s`',
+            reference_parameter_name,
+            reference_parameter_path,
+            actual_checksum,
+            reference_checksum)
 
     return (reference_parameter_name, reference_parameter_path)
 

--- a/nftest/data/nftest.yml
+++ b/nftest/data/nftest.yml
@@ -10,5 +10,10 @@ cases:
     message:
     nf_script:
     nf_config:
+    reference_files:
+      - reference_parameter_name:
+        reference_parameter_path:
+        reference_checksum:
+        reference_checksum_type: 'md5'
     skip: false
     verbose: true

--- a/test/unit/test_common.py
+++ b/test/unit/test_common.py
@@ -1,9 +1,9 @@
 # pylint: disable=W0212
 ''' Test module for common functions '''
 
+import logging
 import mock
 import pytest
-import logging
 
 from nftest.common import resolve_single_path, validate_reference
 

--- a/test/unit/test_common.py
+++ b/test/unit/test_common.py
@@ -3,8 +3,9 @@
 
 import mock
 import pytest
+import logging
 
-from nftest.common import resolve_single_path
+from nftest.common import resolve_single_path, validate_reference
 
 @pytest.mark.parametrize(
     'glob_return_value,case_pass',
@@ -25,3 +26,71 @@ def test_resolve_single_path(mock_glob, glob_return_value, case_pass):
     else:
         with pytest.raises(ValueError):
             resolve_single_path(test_path)
+
+@pytest.mark.parametrize(
+    'param_name,valid_name',
+    [
+        ('bad name', False),
+        ('good_name', True),
+        ('bad#name', False),
+        ('validparam', True)
+    ]
+)
+@mock.patch('nftest.common.calculate_checksum')
+def test_param_names_validate_reference(
+    mock_calculate_checksum,
+    param_name,
+    valid_name):
+    ''' Tests for proper parameter name check '''
+    mock_calculate_checksum.return_value = ''
+    if valid_name:
+        validate_reference(param_name, '', '', '')
+    else:
+        with pytest.raises(ValueError):
+            validate_reference(param_name, '', '', '')
+
+@mock.patch('nftest.common.calculate_checksum')
+def test_warning_with_bad_checksum_validate_reference(
+    mock_calculate_checksum,
+    caplog):
+    ''' Tests for warning message printed with bad checksum '''
+    test_bad_checksum = 'bad_checksum'
+    test_param_name = 'name'
+    test_param_path = 'path'
+    test_checksum = 'checksum'
+    test_checksum_type = 'md5'
+
+    mock_calculate_checksum.return_value = test_bad_checksum
+
+
+    with caplog.at_level(logging.DEBUG):
+        validate_reference(
+            test_param_name,
+            test_param_path,
+            test_checksum,
+            test_checksum_type
+        )
+
+    assert f'Checksum for reference file: ' \
+        f'{test_param_name}={test_param_path} - `' \
+        f'{test_bad_checksum}` does not match expected ' \
+        f'checksum of `{test_checksum}`' in caplog.text
+
+@mock.patch('nftest.common.calculate_checksum')
+def test_returns_correct_tuple_validate_reference(mock_calculate_checksum):
+    ''' Tests for correct return tuple after validation '''
+    test_param_name = 'name'
+    test_param_path = 'path'
+    test_checksum = 'checksum'
+    test_checksum_type = 'md5'
+
+    mock_calculate_checksum.return_value = test_checksum
+
+    validated_reference = validate_reference(
+        test_param_name,
+        test_param_path,
+        test_checksum,
+        test_checksum_type
+    )
+
+    assert validated_reference == (test_param_name, test_param_path)


### PR DESCRIPTION
# Description
<!--- Briefly describe the changes included in this pull request  --->

Adding basic validation for reference checksums, with failed checks resulting in a warning but not failure of test cases

## Pipeline Run Results

Testing log: `/hot/software/package/tool-NFTest/Python/development/unreleased/yashpatel-reference-checksums/log-nftest-20240113T020243Z.log`

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [X] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.


- [X] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [X] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

