### PR TITLE
Capture Nextflow logs via syslog rather than console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 - Make `nftest run` exit with the number of failed tests
 - Use `shell=False` for subprocess
+- Capture Nextflow logs via syslog rather than console
 
 ### Fixed
 - Make `nftest` with no arguments print usage and exit

--- a/nftest/syslog.py
+++ b/nftest/syslog.py
@@ -26,7 +26,7 @@ SYSLOG_RE = re.compile(r"""
     (?P<hostname>\S+)\s             # Hostname
     (?P<message>.*)                 # Message
     $                               # End of line
-    """, re.VERBOSE)
+    """, re.VERBOSE | re.DOTALL)
 MESSAGE_RE = re.compile(r"^nextflow:\s+\w+\s+\[(?P<thread>.+?)\] \S+ - ")
 
 

--- a/nftest/syslog.py
+++ b/nftest/syslog.py
@@ -1,0 +1,104 @@
+"""
+Module for a system to capture Nextflow logs via syslog.
+"""
+import logging
+import re
+import socketserver
+import subprocess
+
+
+LEVELS = [
+    logging.CRITICAL,   # 0 = Emergency
+    logging.CRITICAL,   # 1 = Alert
+    logging.CRITICAL,   # 2 = Critical
+    logging.ERROR,      # 3 = Error
+    logging.WARNING,    # 4 = Warning
+    logging.INFO,       # 5 = Notice
+    logging.INFO,       # 6 = Info
+    logging.DEBUG,      # 7 = Debug
+]
+
+PRIORITY_RE = re.compile(r"^<(\d+)>")
+MESSAGE_RE = re.compile(r"^nextflow:\s+\w+\s+\[(?P<thread>.+?)\] \S+ - ")
+
+
+def syslog_filter(record):
+    """
+    Logging filter to update syslogs from Nextflow with embedded information.
+    """
+    # Nextflow uses BSD-style syslog messages
+    # https://datatracker.ietf.org/doc/html/rfc3164
+    # Format / example:
+    # <PRI>Mmm dd hh:mm:ss HOSTNAME MESSAGE"
+    # <134>Jan  3 12:00:25 ip-0A125232 nextflow: INFO  [main] more...
+    level_month, day, time, addr_message = \
+        record.msg.strip().decode("utf-8").split(maxsplit=3)
+
+    # For errors, the message may begin with whitespace - make sure to only
+    # strip off syslog's required space
+    _, message = addr_message.split(" ", maxsplit=1)
+
+    # The priority is 8 * facility + level - we only care about the level
+    record.levelno = LEVELS[
+        int(PRIORITY_RE.match(level_month).group(1)) % 8
+    ]
+    record.levelname = logging.getLevelName(record.levelno)
+
+    # For most messages, nextflow seems to have a format of:
+    # nextflow: LEVEL [THREAD] MODULE - MESSAGE
+    #
+    # nextflow: DEBUG [main] ConfigBuilder - User config file...
+    # nextflow: INFO  [main] DefaultPluginStatusProvider - Enabled...
+    # nextflow: ERROR [main] Launcher - Unable...
+
+    # Strip off everything before the module if possible
+    thread_match = MESSAGE_RE.match(message)
+    if thread_match:
+        record.msg = MESSAGE_RE.sub("", message)
+        record.threadName = thread_match.group("thread")
+    else:
+        record.msg = message
+        record.threadName = "traceback"
+
+    return record
+
+
+class SyslogServer(socketserver.ThreadingUDPServer):
+    "A UDPServer that logs itself starting up and shutting down."
+    @classmethod
+    def make_server(cls):
+        "Create a server with a random port to handle syslogs."
+        docker_gateway = subprocess.check_output([
+            "docker",
+            "network",
+            "inspect",
+            "bridge",
+            "--format",
+            "{{ (index .IPAM.Config 0).Gateway }}"
+        ]).decode("utf-8").strip()
+
+        return cls(
+            server_address=(docker_gateway, 0),
+            RequestHandlerClass=SyslogHandler
+        )
+
+    def serve_forever(self, poll_interval):
+        logging.getLogger(__name__).debug(
+            "Syslog server at %s:%d starting up",
+            *self.server_address
+        )
+        return super().serve_forever(poll_interval)
+
+    def shutdown(self):
+        logging.getLogger(__name__).debug(
+            "Syslog server at %s:%d shutting down",
+            *self.server_address
+        )
+        return super().shutdown()
+
+
+class SyslogHandler(socketserver.BaseRequestHandler):
+    "A simple syslog-like server to capture formatted logs from Nextflow."
+    def handle(self):
+        # This is a syslog message from Nextflow
+        logging.getLogger("nextflow").info(self.request[0])

--- a/nftest/syslog.py
+++ b/nftest/syslog.py
@@ -4,7 +4,6 @@ Module for a system to capture Nextflow logs via syslog.
 import logging
 import re
 import socketserver
-import subprocess
 
 
 LEVELS = [

--- a/test/unit/test_syslog.py
+++ b/test/unit/test_syslog.py
@@ -1,0 +1,74 @@
+"""Test module for the syslog filter."""
+import logging
+
+from nftest.syslog import syslog_filter, LEVELS
+
+
+def test_syslog_filter(caplog):
+    "Test that the syslog filter works appropriately."
+    caplog.set_level(logging.DEBUG)
+    logging.getLogger("nextflow").addFilter(syslog_filter)
+
+    # This is a well-formatted syslog message
+    logging.getLogger("nextflow").info(
+        b"<132>Jan  3 12:00:25 ip-0A125232 "
+        b"nextflow: ERROR [main] Launcher - Unable..."
+    )
+
+    # A priority of 132 should correspond to a severity of 4, or WARNING
+    assert 132 % 8 == 4
+    assert LEVELS[4] == logging.WARNING
+
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+
+    # The record level comes from `<132>`, not `ERROR`
+    assert record.levelno == logging.WARNING
+    assert record.msg == "Unable..."
+    assert record.name == "nextflow"
+    assert record.threadName == "main"
+
+    # This message has a higher priority
+    logging.getLogger("nextflow").info(
+        b"<130>Jan  3 12:00:25 ip-0A125232 "
+        b"nextflow: ERROR [main] Launcher - Unable..."
+    )
+
+    assert 130 % 8 == 2
+    assert LEVELS[2] == logging.CRITICAL
+
+    assert caplog.record_tuples[-1] == \
+        ("nextflow", logging.CRITICAL, "Unable...")
+
+
+def test_syslog_filter_nonformatted(caplog):
+    "Test that the syslog filter can handle poorly formatted messages."
+    caplog.set_level(logging.DEBUG)
+    logging.getLogger("nextflow").addFilter(syslog_filter)
+
+    logging.getLogger("nextflow").debug("hello")
+    logging.getLogger("nextflow").debug(b"hello")
+
+    assert caplog.record_tuples == [
+        ("nextflow", logging.DEBUG, "hello"),
+        ("nextflow", logging.DEBUG, str(b"hello")),
+    ]
+
+
+def test_syslog_filter_traceback(caplog):
+    "Test that the syslog filter properly handles tracebacks."
+    caplog.set_level(logging.DEBUG)
+    logging.getLogger("nextflow").addFilter(syslog_filter)
+
+    # This is a well-formatted syslog message, but not a well-formatted
+    # Nextflow message. That generally means that it is a traceback.
+    message = b"<132>Jan  3 12:00:25 ip-0A125232 random message"
+
+    logging.getLogger("nextflow").debug(message)
+
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+
+    assert record.levelno == logging.WARNING
+    assert record.msg == "random message"
+    assert record.threadName == "traceback"

--- a/test/unit/test_syslog.py
+++ b/test/unit/test_syslog.py
@@ -41,6 +41,26 @@ def test_syslog_filter(caplog):
         ("nextflow", logging.CRITICAL, "Unable...")
 
 
+def test_syslog_filter_multline(caplog):
+    "Test that the syslog filter handles multiline messages."
+    caplog.set_level(logging.DEBUG)
+    logging.getLogger("nextflow").addFilter(syslog_filter)
+
+    # This is a well-formatted syslog message
+    logging.getLogger("nextflow").info(
+        b"<131>Jan  3 12:00:25 ip-0A125232 "
+        b"nextflow: ERROR [main] Launcher - Unable\nto\nact"
+    )
+
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+
+    assert record.levelno == logging.ERROR
+    assert record.msg == "Unable\nto\nact"
+    assert record.name == "nextflow"
+    assert record.threadName == "main"
+
+
 def test_syslog_filter_nonformatted(caplog):
     "Test that the syslog filter can handle poorly formatted messages."
     caplog.set_level(logging.DEBUG)


### PR DESCRIPTION
# Description
This change uses Nextflow's `-syslog` [command line flag](https://www.nextflow.io/docs/edge/cli.html#logging-to-a-syslog-server) to capture more structured logs than from the console. (The console logs are also suppressed with `-quiet`.) Lines printed to the console are still logged at `INFO`-level to a new `console` logger.

The active thread for each log message is now recorded to the logfile. It is not displayed on the console for simplicity.

```
### console
2024-01-17 20:32:03,951 - NFTest - INFO - Beginning tests...
2024-01-17 20:32:03,952 - NFTest - INFO - A-mini-n2: None

### logfile
2024-01-17 20:32:03,951 - NFTest - MainThread - INFO - Beginning tests...
2024-01-17 20:32:03,952 - NFTest - MainThread - INFO - A-mini-n2: None
```

I also fixed a bug I introduced with #58 where Nextflow logs go to `NFTest` rather than `nextflow`.

Despite the additional complexity there are several advantages to this approach. First, Nextflow only posts "relevant" process statuses, as opposed to the periodic status updates noted in #54:

Before:
```
2024-01-17 20:31:07,041 - NFTest - INFO - executor >  local (8)
2024-01-17 20:31:07,041 - NFTest - INFO - [72/6536cb] process > run_validate_PipeVal (4)       [100%] 4 of 4 ✔
2024-01-17 20:31:07,041 - NFTest - INFO - [03/b45ace] process > run_selectPositions_REDItools  [100%] 1 of 1 ✔
2024-01-17 20:31:07,041 - NFTest - INFO - [36/cefb0e] process > run_AnnotateRepeatMasker_RE... [100%] 1 of 1 ✔
2024-01-17 20:31:07,042 - NFTest - INFO - [93/c89093] process > run_AnnotateGene_REDItools     [100%] 1 of 1 ✔
2024-01-17 20:31:07,042 - NFTest - INFO - [37/57af12] process > run_FilterREDIportal_REDItools [  0%] 0 of 1
2024-01-17 20:31:07,042 - NFTest - INFO -
2024-01-17 20:31:07,042 - NFTest - INFO -
2024-01-17 20:31:07,042 - NFTest - INFO -
2024-01-17 20:31:07,042 - NFTest - INFO -
2024-01-17 20:31:07,042 - NFTest - INFO - Script time --> START: 17/01/2024 20:30:42
2024-01-17 20:31:07,043 - NFTest - INFO - Reading table...
2024-01-17 20:31:07,043 - NFTest - INFO - Total lines: 653
2024-01-17 20:31:07,043 - NFTest - INFO - Filtered in lines: 74
2024-01-17 20:31:07,043 - NFTest - INFO - Selected lines saved on CPCG0196-F1-A-mini-n2_candidates.txt
2024-01-17 20:31:07,043 - NFTest - INFO - Script time --> END: 17/01/2024 20:30:42
2024-01-17 20:31:07,043 - NFTest - INFO -
2024-01-17 20:31:07,043 - NFTest - INFO -
2024-01-17 20:31:07,043 - NFTest - INFO -
2024-01-17 20:31:07,044 - NFTest - INFO -
2024-01-17 20:31:07,115 - NFTest - INFO - executor >  local (8)
2024-01-17 20:31:07,116 - NFTest - INFO - [72/6536cb] process > run_validate_PipeVal (4)       [100%] 4 of 4 ✔
2024-01-17 20:31:07,116 - NFTest - INFO - [03/b45ace] process > run_selectPositions_REDItools  [100%] 1 of 1 ✔
2024-01-17 20:31:07,116 - NFTest - INFO - [36/cefb0e] process > run_AnnotateRepeatMasker_RE... [100%] 1 of 1 ✔
2024-01-17 20:31:07,116 - NFTest - INFO - [93/c89093] process > run_AnnotateGene_REDItools     [100%] 1 of 1 ✔
2024-01-17 20:31:07,116 - NFTest - INFO - [37/57af12] process > run_FilterREDIportal_REDItools [100%] 1 of 1 ✔
```

After:
```
2024-01-17 20:32:22,326 - nextflow - INFO - [01/706655] Submitted process > run_selectPositions_REDItools
2024-01-17 20:32:23,131 - console - INFO - Script time --> START: 17/01/2024 20:32:22
2024-01-17 20:32:23,179 - nextflow - INFO - [0f/1a7d38] Submitted process > run_AnnotateRepeatMasker_REDItools
2024-01-17 20:32:27,876 - nextflow - INFO - [bb/c97103] Submitted process > run_AnnotateGene_REDItools
2024-01-17 20:32:34,434 - nextflow - INFO - [39/0a83e3] Submitted process > run_FilterREDIportal_REDItools
2024-01-17 20:32:43,921 - console - INFO - Reading table...
2024-01-17 20:32:43,921 - console - INFO - Total lines: 653
2024-01-17 20:32:43,921 - console - INFO - Filtered in lines: 74
2024-01-17 20:32:43,921 - console - INFO - Selected lines saved on CPCG0196-F1-A-mini-n2_candidates.txt
2024-01-17 20:32:43,922 - console - INFO - Script time --> END: 17/01/2024 20:32:22
2024-01-17 20:32:43,922 - console - INFO - All positions: 74
2024-01-17 20:32:46,349 - console - INFO - Positions filtered in: 0
```

Second, Nextflow pushes `DEBUG`-level logs, and logs from more modules, to the syslog server. Most of these logs would otherwise only be saved in the `.nextflow.log` file and be very difficult to merge with the NFTest logs:

Before:
```
2024-01-17 20:30:26,970 - NFTest - INFO - N E X T F L O W  ~  version 23.04.2
2024-01-17 20:30:31,855 - NFTest - INFO - Launching `./main.nf` [sick_carson] DSL2 - revision: 7ffe311c28
```

After:
```
2024-01-17 20:32:06,930 - nextflow - main - INFO - N E X T F L O W  ~  version 23.04.2
2024-01-17 20:32:06,954 - nextflow - main - DEBUG - Setting up plugin manager > mode=prod; embedded=false; plugins-dir=/mnt/exports/shared/home/nwiltsie/.nextflow/plugins; core-plugins: nf-amazon@1.16.2,nf-azure@1.0.1,nf-codecommit@0.1.4,nf-console@1.0.5,nf-ga4gh@1.0.5,nf-google@1.7.3,nf-tower@1.5.12,nf-wave@0.8.3
2024-01-17 20:32:07,032 - nextflow - main - INFO - Enabled plugins: []
2024-01-17 20:32:07,042 - nextflow - main - INFO - Disabled plugins: []
2024-01-17 20:32:07,043 - nextflow - main - INFO - PF4J version 3.4.1 in 'deployment' mode
2024-01-17 20:32:07,077 - nextflow - main - INFO - No plugins
2024-01-17 20:32:07,106 - nextflow - main - DEBUG - Found config local: /hot/code/nwiltsie/pipelines/pipeline-filter-RNAEditingSite/nextflow.config
2024-01-17 20:32:07,122 - nextflow - main - DEBUG - User config file: /hot/code/nwiltsie/pipelines/pipeline-filter-RNAEditingSite/test/nftest.config
2024-01-17 20:32:07,122 - nextflow - main - DEBUG - Parsing config file: /hot/code/nwiltsie/pipelines/pipeline-filter-RNAEditingSite/nextflow.config
2024-01-17 20:32:07,123 - nextflow - main - DEBUG - Parsing config file: /hot/code/nwiltsie/pipelines/pipeline-filter-RNAEditingSite/test/nftest.config
2024-01-17 20:32:07,206 - nextflow - main - DEBUG - Applying config profile: `standard`
2024-01-17 20:32:08,386 - nextflow - main - DEBUG - Applying config profile: `standard`
2024-01-17 20:32:11,695 - nextflow - main - DEBUG - Applied DSL=2 from script declararion
2024-01-17 20:32:11,727 - nextflow - main - INFO - Launching `./main.nf` [modest_kirch] DSL2 - revision: 7ffe311c28
```

---

## Nitty-gritty details

[Syslog](https://en.wikipedia.org/wiki/Syslog) is a standard message logging format that is [supported by Nextflow](https://www.nextflow.io/docs/edge/cli.html#logging-to-a-syslog-server).

In order to capture the logs, each test case now spins up a custom [`socketserver.UDPServer`](https://docs.python.org/3/library/socketserver.html#socketserver-udpserver-example) in a separate thread. The server unconditionally logs the raw syslog messages at INFO level to the `nextflow` logger (see below). Context managers make sure that the server (and thus the thread) are both torn down once the `nextflow run` command returns.

Nextflow uses the [BSD syslog format](https://datatracker.ietf.org/doc/html/rfc3164). In order to extract the embedded information from the raw syslog messages (logging level, thread, etc.) I'm using a [filter](https://docs.python.org/3/library/logging.html#filter-objects) attached to the `nextflow` logger.

### Problems

The one irritation is that most syslog implementations (including Nextflow's) are based on UDP and thus are vulnerable to message re-ordering and packet loss. As the server is on the same host and is using a [ThreadingUDPServer](https://docs.python.org/3/library/socketserver.html#socketserver.ThreadingUDPServer) that handles each connection in a new thread, I'm not particularly concerned about dropping packets due to congestion.

_However_, syslog messages are also limited to the size of 1/2 of the system's socket send buffer size (`SO_SNDBUF`, [docs](https://man7.org/linux/man-pages/man7/socket.7.html)), or 8192 bytes on my F2. When a workflow finishes Nextflow logs the entire trace object, which ends up getting truncated:

```
2024-01-17 20:32:44,199 - nextflow - main - DEBUG - Workflow completed -- rendering execution report
2024-01-17 20:32:44,338 - nextflow - main - DEBUG - Execution report summary data:
  [{"cpuUsage": ---snip--- "q2Label":"run_AnnotateGene_RED     <--- That's just the end, no closing quote
2024-01-17 20:32:45,688 - nextflow - main - DEBUG - Workflow completed -- rendering execution timeline
2024-01-17 20:32:46,117 - nextflow - main - DEBUG - Closing CacheDB done
```

The truncated message does not cause any other problems, but it's just incorrect and I don't like it.

### Closes #54 

## Pipeline Run Results

Clean results (before these changes):
* `/hot/software/pipeline/pipeline-filter-RNAEditingSite/Nextflow/development/unreleased/nwiltsie-syslog-testing/log-nftest-20240117T203023Z.log`
* `/hot/software/pipeline/pipeline-filter-RNAEditingSite/Nextflow/development/unreleased/nwiltsie-syslog-testing/sbatch-nftest-20240117T203018Z.log`

Results after these changes:
* `/hot/software/pipeline/pipeline-filter-RNAEditingSite/Nextflow/development/unreleased/nwiltsie-syslog-testing/log-nftest-20240117T203203Z.log`
* `/hot/software/pipeline/pipeline-filter-RNAEditingSite/Nextflow/development/unreleased/nwiltsie-syslog-testing/sbatch-nftest-20240117T203159Z.log`

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [x] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.


- [x] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

