### PR TITLE
Resolve non-determinism with NFTestENV tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 - Make `nftest` with no arguments print usage and exit
+- Resolve non-determinism in NFTestENV unit tests
 
 ---
 

--- a/test/unit/test_NFTestAssert.py
+++ b/test/unit/test_NFTestAssert.py
@@ -12,6 +12,9 @@ from nftest.NFTestAssert import NFTestAssert
 @mock.patch("nftest.NFTestAssert.NFTestAssert", wraps=NFTestAssert)
 def test_get_assert_method_value_error(mock_assert):
     """Tests value error from get_assert_method when given `method` is not supported"""
+    # Make an NFTestAssert object
+    NFTestAssert("", "")
+
     assert_method = "nomethod"
     mock_assert.return_value.script = None
     mock_assert.return_value.method = assert_method

--- a/test/unit/test_NFTestEnv.py
+++ b/test/unit/test_NFTestEnv.py
@@ -17,7 +17,11 @@ def test_nftest_env_load(monkeypatch):
     monkeypatch.setenv("NFT_LOG_LEVEL", test_log_level)
     monkeypatch.setenv("NFT_LOG", test_log_file)
 
+    # Clear any existing singleton value
+    NFTestENV._instances.pop(NFTestENV, None)
     nftest_env = NFTestENV()
+
+    assert NFTestENV in NFTestENV._instances
 
     assert nftest_env.NFT_OUTPUT == test_out_directory
     assert nftest_env.NFT_TEMP == test_temp_directory
@@ -32,3 +36,8 @@ def test_singleton():
     nftest_env2 = NFTestENV()
 
     assert id(nftest_env1) == id(nftest_env2)
+
+    NFTestENV._instances.pop(NFTestENV, None)
+    nftest_env3 = NFTestENV()
+
+    assert id(nftest_env1) != id(nftest_env3)

--- a/test/unit/test_NFTestEnv.py
+++ b/test/unit/test_NFTestEnv.py
@@ -18,10 +18,10 @@ def test_nftest_env_load(monkeypatch):
     monkeypatch.setenv("NFT_LOG", test_log_file)
 
     # Clear any existing singleton value
-    NFTestENV._instances.pop(NFTestENV, None)
+    NFTestENV._instances.pop(NFTestENV, None)   # pylint: disable=protected-access
     nftest_env = NFTestENV()
 
-    assert NFTestENV in NFTestENV._instances
+    assert NFTestENV in NFTestENV._instances    # pylint: disable=protected-access
 
     assert nftest_env.NFT_OUTPUT == test_out_directory
     assert nftest_env.NFT_TEMP == test_temp_directory
@@ -37,7 +37,7 @@ def test_singleton():
 
     assert id(nftest_env1) == id(nftest_env2)
 
-    NFTestENV._instances.pop(NFTestENV, None)
+    NFTestENV._instances.pop(NFTestENV, None)   # pylint: disable=protected-access
     nftest_env3 = NFTestENV()
 
     assert id(nftest_env1) != id(nftest_env3)


### PR DESCRIPTION
# Description
The unit tests for the `NFTestENV` class are written to assume that they are the first callers of `NFTestENV()` within the running process:

https://github.com/uclahs-cds/tool-NFTest/blob/c9cbf2e59994b72d114dc6e9c8104bf6dd47aa1a/test/unit/test_NFTestEnv.py#L14-L26

`NFTestENV` is set up specifically with a `Singleton` metaclass, meaning that it is only ever constructed once. Adding a call to `NFTestENV()` in an unrelated test method causes _this_ test to fail.

I'm not a huge fan of the Singleton pattern for exactly this reason, and I'd like to refactor it out. In the meantime, this PR applies two fixes to the tests:

* `test_nftest_env_load` now pops any existing instance of `NFTestENV` from the Singleton store before constructing a new one with the monkey-patched environment.
* `test_singleton`, in addition to constructing two `NFTestENV`s and asserting they are the same object, resets the store and asserts that a third `NFTestENV` object is _not_ the same object.


I'm pushing my changes up in waves to demonstrate the problem and my fixes to it. 95f078a845a0e0ff9ecea98304ffa573bd59e548, an innocuous change to another test case, should fail.

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [x] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.


- [x] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

