### PR TITLE
Encapsulate NFTestAssert class, rewrite tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Use `shell=False` for subprocess
 - Capture Nextflow logs via syslog rather than console
 - Format all code with ruff
+- Encapsulate NFTestAssert interface, rewrite tests
 
 ### Fixed
 - Make `nftest` with no arguments print usage and exit

--- a/nftest/NFTestAssert.py
+++ b/nftest/NFTestAssert.py
@@ -1,21 +1,23 @@
 """NF Test assert"""
 
 import datetime
-import errno
-import os
 import subprocess
-from typing import Callable
+from typing import Callable, Optional
 from logging import getLogger, DEBUG
 
 from nftest.common import calculate_checksum, resolve_single_path, popen_with_logger
 from nftest.NFTestENV import NFTestENV
 
 
+class NFTestAssertionError(Exception):
+    "An exception indicating that a test assertion failed."
+
+
 class NFTestAssert:
     """Defines how nextflow test results are asserted."""
 
     def __init__(
-        self, actual: str, expect: str, method: str = "md5", script: str = None
+        self, actual: str, expect: str, method: str = "md5", script: Optional[str] = None
     ):
         """Constructor"""
         self._env = NFTestENV()
@@ -27,48 +29,39 @@ class NFTestAssert:
 
         self.startup_time = datetime.datetime.now(tz=datetime.timezone.utc)
 
-    def identify_assertion_files(self) -> None:
-        """Resolve actual and expected paths"""
-        self.actual = resolve_single_path(self.actual)
-        self.expect = resolve_single_path(self.expect)
+    def perform_assertions(self):
+        "Perform the appropriate assertions on the named files."
+        # Ensure that there is exactly one file for each input glob pattern
+        actual_path = resolve_single_path(self.actual)
+        self._logger.debug(
+            "Actual path `%s` resolved to `%s`", self.actual, actual_path
+        )
+        expect_path = resolve_single_path(self.expect)
+        self._logger.debug(
+            "Expected path `%s` resolved to `%s`", self.expect, expect_path
+        )
 
-    def assert_exists(self) -> None:
-        "Assert that the expected and actual files exist."
-        if not self.actual.exists():
-            self._logger.error("Actual file not found: %s", self.actual)
-            raise FileNotFoundError(
-                errno.ENOENT, os.strerror(errno.ENOENT), self.actual
-            )
-
-        if not self.expect.exists():
-            self._logger.error("Expect file not found: %s", self.expect)
-            raise FileNotFoundError(
-                errno.ENOENT, os.strerror(errno.ENOENT), self.expect
-            )
-
-    def assert_updated(self) -> None:
-        "Assert that the actual file was updated during this test run."
+        # Assert that the actual file was updated during this test run
         file_mod_time = datetime.datetime.fromtimestamp(
-            self.actual.stat().st_mtime, tz=datetime.timezone.utc
+            actual_path.stat().st_mtime, tz=datetime.timezone.utc
         )
 
         self._logger.debug("Test creation time: %s", self.startup_time)
         self._logger.debug("Actual mod time:    %s", file_mod_time)
-        assert (
-            file_mod_time > self.startup_time
-        ), f"{str(self.actual)} was not modified by this pipeline"
 
-    def assert_expected(self) -> None:
-        "Assert the results match with the expected values."
-        assert_method = self.get_assert_method()
-        try:
-            assert assert_method(self.actual, self.expect)
-            self._logger.debug("Assertion passed")
-        except AssertionError as error:
+        if self.startup_time >= file_mod_time:
+            raise NFTestAssertionError(
+                f"{str(self.actual)} was not modified by this pipeline"
+            )
+
+        # Assert that the files match
+        if not self.get_assert_method()(actual_path, expect_path):
             self._logger.error("Assertion failed")
             self._logger.error("Actual: %s", self.actual)
             self._logger.error("Expect: %s", self.expect)
-            raise error
+            raise NFTestAssertionError("File comparison failed")
+
+        self._logger.debug("Assertion passed")
 
     def get_assert_method(self) -> Callable:
         """Get the assert method"""

--- a/nftest/NFTestAssert.py
+++ b/nftest/NFTestAssert.py
@@ -9,8 +9,12 @@ from nftest.common import calculate_checksum, resolve_single_path, popen_with_lo
 from nftest.NFTestENV import NFTestENV
 
 
-class NFTestAssertionError(Exception):
-    "An exception indicating that a test assertion failed."
+class NotUpdatedError(Exception):
+    "An exception indicating that file was not updated."
+
+
+class MismatchedContentsError(Exception):
+    "An exception that the contents are mismatched."
 
 
 class NFTestAssert:
@@ -50,7 +54,7 @@ class NFTestAssert:
         self._logger.debug("Actual mod time:    %s", file_mod_time)
 
         if self.startup_time >= file_mod_time:
-            raise NFTestAssertionError(
+            raise NotUpdatedError(
                 f"{str(self.actual)} was not modified by this pipeline"
             )
 
@@ -59,7 +63,7 @@ class NFTestAssert:
             self._logger.error("Assertion failed")
             self._logger.error("Actual: %s", self.actual)
             self._logger.error("Expect: %s", self.expect)
-            raise NFTestAssertionError("File comparison failed")
+            raise MismatchedContentsError("File comparison failed")
 
         self._logger.debug("Assertion passed")
 

--- a/nftest/NFTestAssert.py
+++ b/nftest/NFTestAssert.py
@@ -1,6 +1,7 @@
 """NF Test assert"""
 
 import datetime
+import os
 import subprocess
 from typing import Callable, Optional
 from logging import getLogger, DEBUG
@@ -51,7 +52,7 @@ class NFTestAssert:
 
         # Assert that the actual file was updated during this test run
         file_mod_time = datetime.datetime.fromtimestamp(
-            actual_path.stat().st_mtime, tz=datetime.timezone.utc
+            os.stat(actual_path).st_mtime, tz=datetime.timezone.utc
         )
 
         self._logger.debug("Test creation time: %s", self.startup_time)

--- a/nftest/NFTestAssert.py
+++ b/nftest/NFTestAssert.py
@@ -69,10 +69,8 @@ class NFTestAssert:
 
     def get_assert_method(self) -> Callable:
         """Get the assert method"""
-        # pylint: disable=E0102
         if self.script is not None:
-
-            def func(actual, expect):
+            def script_function(actual, expect):
                 cmd = [self.script, actual, expect]
                 self._logger.debug(subprocess.list2cmdline(cmd))
 
@@ -81,15 +79,16 @@ class NFTestAssert:
                 )
                 return process.returncode == 0
 
-            return func
-        if self.method == "md5":
+            return script_function
 
-            def func(actual, expect):
+        if self.method == "md5":
+            def md5_function(actual, expect):
                 self._logger.debug("md5 %s %s", actual, expect)
                 actual_value = calculate_checksum(actual)
                 expect_value = calculate_checksum(expect)
                 return actual_value == expect_value
 
-            return func
+            return md5_function
+
         self._logger.error("assert method %s unknown.", self.method)
         raise ValueError(f"assert method {self.method} unknown.")

--- a/nftest/NFTestAssert.py
+++ b/nftest/NFTestAssert.py
@@ -21,7 +21,11 @@ class NFTestAssert:
     """Defines how nextflow test results are asserted."""
 
     def __init__(
-        self, actual: str, expect: str, method: str = "md5", script: Optional[str] = None
+        self,
+        actual: str,
+        expect: str,
+        method: str = "md5",
+        script: Optional[str] = None,
     ):
         """Constructor"""
         self._env = NFTestENV()
@@ -70,6 +74,7 @@ class NFTestAssert:
     def get_assert_method(self) -> Callable:
         """Get the assert method"""
         if self.script is not None:
+
             def script_function(actual, expect):
                 cmd = [self.script, actual, expect]
                 self._logger.debug(subprocess.list2cmdline(cmd))
@@ -82,6 +87,7 @@ class NFTestAssert:
             return script_function
 
         if self.method == "md5":
+
             def md5_function(actual, expect):
                 self._logger.debug("md5 %s %s", actual, expect)
                 actual_value = calculate_checksum(actual)

--- a/nftest/NFTestAssert.py
+++ b/nftest/NFTestAssert.py
@@ -1,7 +1,6 @@
 """NF Test assert"""
 
 import datetime
-import os
 import subprocess
 from typing import Callable, Optional
 from logging import getLogger, DEBUG
@@ -52,7 +51,7 @@ class NFTestAssert:
 
         # Assert that the actual file was updated during this test run
         file_mod_time = datetime.datetime.fromtimestamp(
-            os.stat(actual_path).st_mtime, tz=datetime.timezone.utc
+            actual_path.stat().st_mtime, tz=datetime.timezone.utc
         )
 
         self._logger.debug("Test creation time: %s", self.startup_time)

--- a/nftest/NFTestCase.py
+++ b/nftest/NFTestCase.py
@@ -109,12 +109,9 @@ class NFTestCase:
             self._logger.error(" [ failed ]")
             return False
 
-        for ass in self.asserts:
+        for assertion in self.asserts:
             try:
-                ass.identify_assertion_files()
-                ass.assert_exists()
-                ass.assert_updated()
-                ass.assert_expected()
+                assertion.perform_assertions()
             except Exception as error:
                 self._logger.error(error.args)
                 self._logger.error(" [ failed ]")

--- a/nftest/NFTestCase.py
+++ b/nftest/NFTestCase.py
@@ -27,8 +27,7 @@ if TYPE_CHECKING:
 class NFTestCase:
     """Defines the NF test case"""
 
-    # pylint: disable=R0902
-    # pylint: disable=R0913
+    # pylint: disable=too-many-instance-attributes
     def __init__(
         self,
         name: str = None,

--- a/nftest/NFTestENV.py
+++ b/nftest/NFTestENV.py
@@ -7,11 +7,11 @@ from dotenv import load_dotenv
 from nftest.Singleton import Singleton
 
 
-# pylint: disable=C0103
 @dataclass
 class NFTestENV(metaclass=Singleton):
     """Class for initializng and holding environment variables."""
 
+    # pylint: disable=invalid-name
     NFT_OUTPUT: str = field(init=False)
     NFT_TEMP: str = field(init=False)
     NFT_INIT: str = field(init=False)

--- a/nftest/NFTestGlobal.py
+++ b/nftest/NFTestGlobal.py
@@ -6,8 +6,8 @@ from nftest.NFTestENV import NFTestENV
 
 class NFTestGlobal:
     """Test global settings"""
+    # pylint: disable=too-few-public-methods
 
-    # pylint: disable=R0903
     def __init__(
         self,
         temp_dir: str,

--- a/nftest/NFTestGlobal.py
+++ b/nftest/NFTestGlobal.py
@@ -6,6 +6,7 @@ from nftest.NFTestENV import NFTestENV
 
 class NFTestGlobal:
     """Test global settings"""
+
     # pylint: disable=too-few-public-methods
 
     def __init__(

--- a/nftest/__main__.py
+++ b/nftest/__main__.py
@@ -35,7 +35,6 @@ def parse_args() -> argparse.Namespace:
     return args
 
 
-# pylint: disable=W0212
 def add_subparser_init(subparsers: argparse._SubParsersAction):
     """Add subparser for init"""
     parser: argparse.ArgumentParser = subparsers.add_parser(

--- a/nftest/common.py
+++ b/nftest/common.py
@@ -81,6 +81,9 @@ def validate_reference(
 
     _logger = logging.getLogger("NFTest")
 
+    if reference_checksum_type.lower() not in {"md5"}:
+        _logger.warning("reference_checksum_type must be `md5`")
+
     actual_checksum = calculate_checksum(Path(reference_parameter_path))
 
     if actual_checksum != reference_checksum:

--- a/nftest/common.py
+++ b/nftest/common.py
@@ -41,10 +41,13 @@ def remove_nextflow_logs() -> None:
 def resolve_single_path(path: str) -> Path:
     """Resolve wildcards in path and ensure only a single path is identified"""
     expanded_paths = glob.glob(path)
-    if 1 != len(expanded_paths):
+
+    if not expanded_paths:
+        raise ValueError(f"Expression `{path}` did not resolve to any files")
+
+    if len(expanded_paths) > 1:
         raise ValueError(
-            f"Path `{path}` resolved to 0 or more than 1 file: {expanded_paths}."
-            " Assertion failed."
+            f"Expression `{path}` resolved to multiple files: {expanded_paths}"
         )
 
     return Path(expanded_paths[0])

--- a/nftest/common.py
+++ b/nftest/common.py
@@ -79,9 +79,6 @@ def validate_reference(
             f"Please use only alphanumeric, _, -, and . characters in parameter names."
         )
 
-    if reference_checksum_type.lower() not in {"md5"}:
-        raise ValueError("reference_checksum_type must be `md5`")
-
     _logger = logging.getLogger("NFTest")
 
     actual_checksum = calculate_checksum(Path(reference_parameter_path))

--- a/nftest/common.py
+++ b/nftest/common.py
@@ -20,8 +20,7 @@ from nftest.NFTestENV import NFTestENV
 from nftest.syslog import syslog_filter
 
 
-# pylint: disable=W0613
-def validate_yaml(path: Path):
+def validate_yaml(path: Path):  # pylint: disable=unused-argument
     """Validate the yaml. Potentially use yaml schema
     https://rx.codesimply.com/
     """
@@ -80,6 +79,9 @@ def validate_reference(
             f"Please use only alphanumeric, _, -, and . characters in parameter names."
         )
 
+    if reference_checksum_type.lower() not in {"md5"}:
+        raise ValueError("reference_checksum_type must be `md5`")
+
     _logger = logging.getLogger("NFTest")
 
     actual_checksum = calculate_checksum(Path(reference_parameter_path))
@@ -129,7 +131,7 @@ def setup_loggers():
     # Make a stream handler with the requested verbosity
     stream_handler = logging.StreamHandler(sys.stdout)
     try:
-        stream_handler.setLevel(logging._checkLevel(_env.NFT_LOG_LEVEL))  # pylint: disable=W0212
+        stream_handler.setLevel(_env.NFT_LOG_LEVEL)
     except ValueError:
         stream_handler.setLevel(logging.INFO)
 

--- a/test/unit/test_NFTestAssert.py
+++ b/test/unit/test_NFTestAssert.py
@@ -120,11 +120,11 @@ def fixture_configured_test(
         expect_file = tmp_path / f"{index}.expect"
         expect_file.write_text(file_contents[0], encoding="utf-8")
 
-    actual_file = None
-
-    for index in range(actual_count):
-        actual_file = tmp_path / f"{index}.actual"
-        actual_file.write_text(file_contents[1], encoding="utf-8")
+    if not file_updated:
+        # Create the actual files before the test
+        for index in range(actual_count):
+            actual_file = tmp_path / f"{index}.actual"
+            actual_file.write_text(file_contents[1], encoding="utf-8")
 
     assertion = NFTestAssert(
         expect=str(tmp_path / "*.expect"),
@@ -133,8 +133,11 @@ def fixture_configured_test(
         method=method,
     )
 
-    if file_updated and actual_file is not None:
-        os.utime(actual_file)
+    if file_updated:
+        # Create the actual files after the test
+        for index in range(actual_count):
+            actual_file = tmp_path / f"{index}.actual"
+            actual_file.write_text(file_contents[1], encoding="utf-8")
 
     return assertion
 

--- a/test/unit/test_NFTestAssert.py
+++ b/test/unit/test_NFTestAssert.py
@@ -1,9 +1,9 @@
 """Test module for NFTestAssert"""
 
 import logging
-import os
 import stat
 import textwrap
+import time
 
 import pytest
 
@@ -135,6 +135,8 @@ def fixture_configured_test(
 
     if file_updated:
         # Create the actual files after the test
+        # Add in an explicit sleep to separate the times
+        time.sleep(0.01)
         for index in range(actual_count):
             actual_file = tmp_path / f"{index}.actual"
             actual_file.write_text(file_contents[1], encoding="utf-8")

--- a/test/unit/test_NFTestAssert.py
+++ b/test/unit/test_NFTestAssert.py
@@ -133,7 +133,7 @@ def fixture_configured_test(
     )
 
     if file_updated and actual_file is not None:
-        actual_file.touch()
+        actual_file.write_bytes(actual_file.read_bytes())
 
     return assertion
 

--- a/test/unit/test_NFTestAssert.py
+++ b/test/unit/test_NFTestAssert.py
@@ -3,6 +3,7 @@
 import logging
 import stat
 import textwrap
+import time
 
 import pytest
 
@@ -133,6 +134,7 @@ def fixture_configured_test(
     )
 
     if file_updated and actual_file is not None:
+        time.sleep(0.1)
         actual_file.write_bytes(actual_file.read_bytes())
 
     return assertion

--- a/test/unit/test_NFTestAssert.py
+++ b/test/unit/test_NFTestAssert.py
@@ -1,6 +1,7 @@
 """Test module for NFTestAssert"""
 
 import logging
+import os
 import stat
 import textwrap
 
@@ -133,10 +134,7 @@ def fixture_configured_test(
     )
 
     if file_updated and actual_file is not None:
-        # Unlink and re-write the file
-        temp_content = actual_file.read_bytes()
-        actual_file.unlink()
-        actual_file.write_bytes(temp_content)
+        os.utime(actual_file)
 
     return assertion
 

--- a/test/unit/test_NFTestAssert.py
+++ b/test/unit/test_NFTestAssert.py
@@ -1,15 +1,12 @@
 """Test module for NFTestAssert"""
+
 import logging
 import stat
 import textwrap
 
 import pytest
 
-from nftest.NFTestAssert import (
-    NFTestAssert,
-    NotUpdatedError,
-    MismatchedContentsError
-)
+from nftest.NFTestAssert import NFTestAssert, NotUpdatedError, MismatchedContentsError
 
 
 @pytest.fixture(name="custom_script", params=[True, False])
@@ -25,7 +22,8 @@ def fixture_custom_script(request, tmp_path):
     # Write a custom script that prints out an obvious sentinel value then
     # executes `diff`
     script = tmp_path / "testscript.sh"
-    script.write_text(textwrap.dedent("""\
+    script.write_text(
+        textwrap.dedent("""\
         #!/bin/bash
         set -euo pipefail
 
@@ -33,22 +31,33 @@ def fixture_custom_script(request, tmp_path):
 
         exec diff "$@"
         """),
-        encoding="utf-8")
+        encoding="utf-8",
+    )
 
     script.chmod(script.stat().st_mode | stat.S_IXUSR)
     return script
 
 
-@pytest.fixture(name="method", params=["md5", ])
+@pytest.fixture(
+    name="method",
+    params=[
+        "md5",
+    ],
+)
 def fixture_method(request):
     "A fixture for the NFTestAssert `method` argument."
     return request.param
 
 
-@pytest.fixture(name="file_updated", params=[
-    True,
-    pytest.param(False, marks=pytest.mark.xfail(strict=True, raises=NotUpdatedError))
-])
+@pytest.fixture(
+    name="file_updated",
+    params=[
+        True,
+        pytest.param(
+            False, marks=pytest.mark.xfail(strict=True, raises=NotUpdatedError)
+        ),
+    ],
+)
 def fixture_file_updated(request):
     "A fixture for whether the actual file was modified during the test."
     return request.param
@@ -73,29 +82,36 @@ def fixture_expect_count(request):
     return request.param
 
 
-@pytest.fixture(name="file_contents", params=[
-    ("", ""),
-    ("matching", "matching"),
-    pytest.param(
-        ("something", ""),
-        marks=pytest.mark.xfail(strict=True, raises=MismatchedContentsError)),
-    pytest.param(
-        ("something", "SOMETHING"),
-        marks=pytest.mark.xfail(strict=True, raises=MismatchedContentsError)),
-])
+@pytest.fixture(
+    name="file_contents",
+    params=[
+        ("", ""),
+        ("matching", "matching"),
+        pytest.param(
+            ("something", ""),
+            marks=pytest.mark.xfail(strict=True, raises=MismatchedContentsError),
+        ),
+        pytest.param(
+            ("something", "SOMETHING"),
+            marks=pytest.mark.xfail(strict=True, raises=MismatchedContentsError),
+        ),
+    ],
+)
 def fixture_file_contents(request):
     "A fixture for the contents of the expect and actual files."
     return request.param
 
 
 @pytest.fixture(name="configured_test")
-def fixture_configured_test(tmp_path,
-                            custom_script,
-                            method,
-                            expect_count,
-                            actual_count,
-                            file_updated,
-                            file_contents):
+def fixture_configured_test(
+    tmp_path,
+    custom_script,
+    method,
+    expect_count,
+    actual_count,
+    file_updated,
+    file_contents,
+):
     """
     A fixture to set up an NFTestAssert referring to a temporary directory.
     """
@@ -113,7 +129,7 @@ def fixture_configured_test(tmp_path,
         expect=str(tmp_path / "*.expect"),
         actual=str(tmp_path / "*.actual"),
         script=custom_script,
-        method=method
+        method=method,
     )
 
     if file_updated and actual_file is not None:

--- a/test/unit/test_NFTestAssert.py
+++ b/test/unit/test_NFTestAssert.py
@@ -133,7 +133,10 @@ def fixture_configured_test(
     )
 
     if file_updated and actual_file is not None:
-        actual_file.write_bytes(actual_file.read_bytes())
+        # Unlink and re-write the file
+        temp_content = actual_file.read_bytes()
+        actual_file.unlink()
+        actual_file.write_bytes(temp_content)
 
     return assertion
 

--- a/test/unit/test_NFTestAssert.py
+++ b/test/unit/test_NFTestAssert.py
@@ -3,7 +3,6 @@
 import logging
 import stat
 import textwrap
-import time
 
 import pytest
 
@@ -134,7 +133,6 @@ def fixture_configured_test(
     )
 
     if file_updated and actual_file is not None:
-        time.sleep(0.1)
         actual_file.write_bytes(actual_file.read_bytes())
 
     return assertion

--- a/test/unit/test_NFTestEnv.py
+++ b/test/unit/test_NFTestEnv.py
@@ -18,10 +18,10 @@ def test_nftest_env_load(monkeypatch):
     monkeypatch.setenv("NFT_LOG", test_log_file)
 
     # Clear any existing singleton value
-    NFTestENV._instances.pop(NFTestENV, None)   # pylint: disable=protected-access
+    NFTestENV._instances.pop(NFTestENV, None)  # pylint: disable=protected-access
     nftest_env = NFTestENV()
 
-    assert NFTestENV in NFTestENV._instances    # pylint: disable=protected-access
+    assert NFTestENV in NFTestENV._instances  # pylint: disable=protected-access
 
     assert nftest_env.NFT_OUTPUT == test_out_directory
     assert nftest_env.NFT_TEMP == test_temp_directory
@@ -37,7 +37,7 @@ def test_singleton():
 
     assert id(nftest_env1) == id(nftest_env2)
 
-    NFTestENV._instances.pop(NFTestENV, None)   # pylint: disable=protected-access
+    NFTestENV._instances.pop(NFTestENV, None)  # pylint: disable=protected-access
     nftest_env3 = NFTestENV()
 
     assert id(nftest_env1) != id(nftest_env3)


### PR DESCRIPTION
# Description
This PR rewrites most of the internals of `NFTestAssert` in a way that is (mostly) invisible to the outside world. This is the key interface change:

```diff
@@ -109,12 +108,9 @@ class NFTestCase:
             self._logger.error(" [ failed ]")
             return False

-        for ass in self.asserts:
+        for assertion in self.asserts:
             try:
-                ass.identify_assertion_files()
-                ass.assert_exists()
-                ass.assert_updated()
-                ass.assert_expected()
+                assertion.perform_assertions()
             except Exception as error:
                 self._logger.error(error.args)
                 self._logger.error(" [ failed ]")
```

The new `perform_assertions()` method hides all of the details of `identify_assertion_files()`, `assert_exists()`, `assert_updated()`, and `assert_expected()`. Decoupling the interface from the implementation details like that makes it easier to test and maintain this code.

In that spirit, I've also re-written all of the tests to test the functionality of the class rather than the implementation details. There are a variety of test fixtures that create an `NFTestAssert` instance pointing to reference and updated files in a temporary directory. The fixtures are parameterized to test the following situations:

* Usage of a custom `script`
* The `actual` file was/wasn't updated after the `NFTestAssert` was created
* There are 0, 1, or 2 files matching the `actual` glob
* There are 0, 1, or 2 files matching the `expect` glob
* The `actual` and `expect` files do/don't have the same content

Those parameters are matched with appropriate [`xfail`](https://docs.pytest.org/en/8.1.x/reference/reference.html#pytest-mark-xfail) marks to confirm that the tests do/don't pass in the expected situations. (Aside: by default `xfail` has `strict=False`, meaning that tests that unexpectedly pass do _not_ raise errors. That is bonkers.)


# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [x] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.


- [x] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.