### PR TITLE
Add `--report` flag to save JSON test summary 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+- Add `--report` flag to write out a summary JSON file
+
 ### Fixed
 - Properly catch failing test cases
 

--- a/nftest/NFTestAssert.py
+++ b/nftest/NFTestAssert.py
@@ -3,11 +3,10 @@
 import datetime
 import glob
 import subprocess
-from typing import Callable, Optional
-from logging import getLogger, DEBUG
 
+from logging import getLogger, DEBUG
 from pathlib import Path
-from typing import List
+from typing import Callable, Optional, List
 
 from nftest.common import calculate_checksum, popen_with_logger
 from nftest.NFTestENV import NFTestENV

--- a/nftest/NFTestAssert.py
+++ b/nftest/NFTestAssert.py
@@ -7,6 +7,7 @@ from typing import Callable, Optional
 from logging import getLogger, DEBUG
 
 from pathlib import Path
+from typing import List
 
 from nftest.common import calculate_checksum, popen_with_logger
 from nftest.NFTestENV import NFTestENV
@@ -35,7 +36,7 @@ class MismatchedContentsError(NFTestAssertionError):
 
 class NonSpecificGlobError(NFTestAssertionError):
     """An exception that the glob did not resolve to a single file."""
-    def __init__(self, globstr: str, paths: list[str]):
+    def __init__(self, globstr: str, paths: List[str]):
         self.globstr = globstr
         self.paths = paths
 

--- a/nftest/NFTestReport.py
+++ b/nftest/NFTestReport.py
@@ -7,6 +7,7 @@ import os
 from contextlib import contextmanager
 from dataclasses import dataclass, field, asdict
 from pathlib import Path
+from typing import Dict
 
 from nftest.common import TestResult
 from nftest.NFTestCase import NFTestCase
@@ -29,10 +30,10 @@ class NFTestReport:
         default_factory=lambda: datetime.datetime.now(tz=datetime.timezone.utc)
     )
 
-    passed_tests: dict[str, float] = field(default_factory=dict)
-    skipped_tests: dict[str, float] = field(default_factory=dict)
-    errored_tests: dict[str, float] = field(default_factory=dict)
-    failed_tests: dict[str, float] = field(default_factory=dict)
+    passed_tests: Dict[str, float] = field(default_factory=dict)
+    skipped_tests: Dict[str, float] = field(default_factory=dict)
+    errored_tests: Dict[str, float] = field(default_factory=dict)
+    failed_tests: Dict[str, float] = field(default_factory=dict)
 
     def __bool__(self):
         return not self.failed_tests

--- a/nftest/NFTestReport.py
+++ b/nftest/NFTestReport.py
@@ -2,8 +2,14 @@
 
 import datetime
 import json
+import os
+
+from contextlib import contextmanager
 from dataclasses import dataclass, field, asdict
 from pathlib import Path
+
+from nftest.common import TestResult
+from nftest.NFTestCase import NFTestCase
 
 
 class DateEncoder(json.JSONEncoder):
@@ -16,27 +22,48 @@ class DateEncoder(json.JSONEncoder):
 
 
 @dataclass
-class TestReport:
+class NFTestReport:
     """Test summary report."""
 
     start: datetime.datetime = field(
         default_factory=lambda: datetime.datetime.now(tz=datetime.timezone.utc)
     )
 
-    passed_tests: list[str] = field(default_factory=list)
-    skipped_tests: list[str] = field(default_factory=list)
-    failed_tests: list[str] = field(default_factory=list)
+    passed_tests: dict[str, float] = field(default_factory=dict)
+    skipped_tests: dict[str, float] = field(default_factory=dict)
+    errored_tests: dict[str, float] = field(default_factory=dict)
+    failed_tests: dict[str, float] = field(default_factory=dict)
 
     def __bool__(self):
         return not self.failed_tests
+
+    @contextmanager
+    def track_test(self, test: NFTestCase):
+        """Context manager to track test statuses and runtimes."""
+        start_time = datetime.datetime.now()
+
+        result_map = {
+            TestResult.PASSED: self.passed_tests,
+            TestResult.SKIPPED: self.skipped_tests,
+            TestResult.ERRORED: self.errored_tests,
+            TestResult.FAILED: self.failed_tests,
+            TestResult.PENDING: {}
+        }
+
+        try:
+            yield
+        finally:
+            duration = (datetime.datetime.now() - start_time).total_seconds()
+            result_map[test.status][test.name] = duration
 
     def write_report(self, reportfile: Path):
         """Write the report out to the given file."""
         data = asdict(self)
 
         # Add extra parameters
+        data["cpus"] = os.cpu_count()
         data["end"] = datetime.datetime.now(tz=datetime.timezone.utc)
-        data["success"] = not self.failed_tests
+        data["success"] = not self.failed_tests and not self.errored_tests
 
         with reportfile.open(mode="wt", encoding="utf-8") as outfile:
             json.dump(data, outfile, indent=2, cls=DateEncoder)

--- a/nftest/NFTestReport.py
+++ b/nftest/NFTestReport.py
@@ -1,0 +1,42 @@
+"""Test summary report."""
+
+import datetime
+import json
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+
+
+class DateEncoder(json.JSONEncoder):
+    """Simple encoder that handles datetimes."""
+    def default(self, o):
+        if isinstance(o, datetime.datetime):
+            return o.isoformat()
+
+        return super().default(o)
+
+
+@dataclass
+class TestReport:
+    """Test summary report."""
+
+    start: datetime.datetime = field(
+        default_factory=lambda: datetime.datetime.now(tz=datetime.timezone.utc)
+    )
+
+    passed_tests: list[str] = field(default_factory=list)
+    skipped_tests: list[str] = field(default_factory=list)
+    failed_tests: list[str] = field(default_factory=list)
+
+    def __bool__(self):
+        return not self.failed_tests
+
+    def write_report(self, reportfile: Path):
+        """Write the report out to the given file."""
+        data = asdict(self)
+
+        # Add extra parameters
+        data["end"] = datetime.datetime.now(tz=datetime.timezone.utc)
+        data["success"] = not self.failed_tests
+
+        with reportfile.open(mode="wt", encoding="utf-8") as outfile:
+            json.dump(data, outfile, indent=2, cls=DateEncoder)

--- a/nftest/NFTestRunner.py
+++ b/nftest/NFTestRunner.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import List
 import yaml
 from nftest.NFTestGlobal import NFTestGlobal
-from nftest.NFTestAssert import NFTestAssert
+from nftest.NFTestAssert import NFTestAssert, NFTestAssertionError
 from nftest.NFTestCase import NFTestCase
 from nftest.NFTestENV import NFTestENV
 from nftest.NFTestReport import NFTestReport
@@ -65,9 +65,14 @@ class NFTestRunner:
                 try:
                     if not case.test():
                         failure_count += 1
-                except AssertionError:
+                except NFTestAssertionError as err:
                     # In case of failed test case, continue with other cases
+                    self._logger.debug(err)
                     failure_count += 1
+                except Exception as err:
+                    # Unhandled error
+                    self._logger.exception(err)
+                    raise
 
         assert failure_count == len(report.failed_tests) + len(report.errored_tests)
 

--- a/nftest/__main__.py
+++ b/nftest/__main__.py
@@ -78,7 +78,7 @@ def run(args):
     """Run"""
     find_config_yaml(args)
     setup_loggers()
-    runner = NFTestRunner(args.report)
+    runner = NFTestRunner(report=args.report)
     runner.load_from_config(args.config_file, args.TEST_CASES)
     sys.exit(runner.main())
 

--- a/nftest/__main__.py
+++ b/nftest/__main__.py
@@ -64,6 +64,11 @@ def add_subparser_run(subparsers: argparse._SubParsersAction):
         nargs="?",
     )
     parser.add_argument(
+        "--report",
+        action="store_true",
+        help="Save out a detailed JSON test report alongside the log file"
+    )
+    parser.add_argument(
         "TEST_CASES", type=str, help="Exact test case to run.", nargs="*"
     )
     parser.set_defaults(func=run)
@@ -73,7 +78,7 @@ def run(args):
     """Run"""
     find_config_yaml(args)
     setup_loggers()
-    runner = NFTestRunner()
+    runner = NFTestRunner(args.report)
     runner.load_from_config(args.config_file, args.TEST_CASES)
     sys.exit(runner.main())
 

--- a/nftest/common.py
+++ b/nftest/common.py
@@ -47,21 +47,6 @@ def remove_nextflow_logs() -> None:
             os.remove(file)
 
 
-def resolve_single_path(path: str) -> Path:
-    """Resolve wildcards in path and ensure only a single path is identified"""
-    expanded_paths = glob.glob(path)
-
-    if not expanded_paths:
-        raise ValueError(f"Expression `{path}` did not resolve to any files")
-
-    if len(expanded_paths) > 1:
-        raise ValueError(
-            f"Expression `{path}` resolved to multiple files: {expanded_paths}"
-        )
-
-    return Path(expanded_paths[0])
-
-
 def calculate_checksum(path: Path) -> str:
     """Calculate checksum recursively.
     Args:

--- a/nftest/common.py
+++ b/nftest/common.py
@@ -1,12 +1,12 @@
 """Common functions"""
 
 import argparse
-import re
-from typing import Tuple
+import enum
 import glob
 import hashlib
 import logging
 import os
+import re
 import selectors
 import shutil
 import subprocess
@@ -14,10 +14,20 @@ import sys
 import time
 
 from pathlib import Path
+from typing import Tuple
 
 from nftest import __version__
 from nftest.NFTestENV import NFTestENV
 from nftest.syslog import syslog_filter
+
+
+class TestResult(enum.Enum):
+    """Enumeration for test results."""
+    PENDING = enum.auto()
+    PASSED = enum.auto()
+    SKIPPED = enum.auto()
+    FAILED = enum.auto()
+    ERRORED = enum.auto()
 
 
 def validate_yaml(path: Path):  # pylint: disable=unused-argument

--- a/test/unit/test_NFTestAssert.py
+++ b/test/unit/test_NFTestAssert.py
@@ -9,7 +9,7 @@ from collections import namedtuple
 
 import pytest
 
-from nftest.NFTestAssert import NFTestAssert, NotUpdatedError, MismatchedContentsError
+from nftest.NFTestAssert import NFTestAssert, NotUpdatedError, MismatchedContentsError, NonSpecificGlobError
 
 
 @pytest.fixture(name="custom_script")
@@ -127,9 +127,9 @@ def fixture_configured_test(
 # Parameterization for the number of expected and actual files matching the
 # globs. Failure is expected for anything except 1.
 FILECOUNT_PARAMS = [
-    pytest.param(0, marks=pytest.mark.xfailgroup.with_args(ValueError)),
+    pytest.param(0, marks=pytest.mark.xfailgroup.with_args(NonSpecificGlobError)),
     1,
-    pytest.param(2, marks=pytest.mark.xfailgroup.with_args(ValueError)),
+    pytest.param(2, marks=pytest.mark.xfailgroup.with_args(NonSpecificGlobError)),
 ]
 
 

--- a/test/unit/test_NFTestAssert.py
+++ b/test/unit/test_NFTestAssert.py
@@ -9,7 +9,12 @@ from collections import namedtuple
 
 import pytest
 
-from nftest.NFTestAssert import NFTestAssert, NotUpdatedError, MismatchedContentsError, NonSpecificGlobError
+from nftest.NFTestAssert import (
+    NFTestAssert,
+    NotUpdatedError,
+    MismatchedContentsError,
+    NonSpecificGlobError,
+)
 
 
 @pytest.fixture(name="custom_script")
@@ -49,7 +54,7 @@ def fixture_custom_script(request, tmp_path):
 
 @pytest.fixture(name="method")
 def fixture_method(request):
-    "A fixture for the NFTestAssert `method` argument."
+    """A fixture for the NFTestAssert `method` argument."""
     return request.param
 
 
@@ -171,7 +176,7 @@ FILEUPDATED_PARAMS = [
 def test_nftest_assert(
     configured_test, caplog, custom_script, actual_files, file_updated
 ):
-    "Test that assertions appropriately pass or fail based on the parameters."
+    """Test that assertions appropriately pass or fail based on the parameters."""
 
     # Time is monotonic, right?
     assert configured_test.startup_time <= datetime.datetime.now(

--- a/test/unit/test_common.py
+++ b/test/unit/test_common.py
@@ -5,23 +5,7 @@ import logging
 import mock
 import pytest
 
-from nftest.common import resolve_single_path, validate_reference
-
-
-@pytest.mark.parametrize(
-    "glob_return_value,case_pass", [([], False), (["a", "b"], False), (["a"], True)]
-)
-@mock.patch("glob.glob")
-def test_resolve_single_path(mock_glob, glob_return_value, case_pass):
-    """Tests for proper file identification"""
-    test_path = "/some/path"
-    mock_glob.return_value = glob_return_value
-
-    if case_pass:
-        resolve_single_path(test_path)
-    else:
-        with pytest.raises(ValueError):
-            resolve_single_path(test_path)
+from nftest.common import validate_reference
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description
This adds a `--report` flag that writes out a JSON test summary file alongside the NFTest log file. As an example, see `/hot/software/pipeline/pipeline-convert-BAM2FASTQ/Nextflow/development/unreleased/main/log-nftest-20240909T225839Z.json`:

```json
{
  "start": "2024-09-09T22:58:39.724080+00:00",
  "passed_tests": {
    "test_bam2fastq": 112.80969
  },
  "skipped_tests": {},
  "errored_tests": {},
  "failed_tests": {},
  "cpus": 2,
  "end": "2024-09-09T23:00:32.534372+00:00",
  "success": true
}
```

This is related to but not quite the same thing as #7 - this saves the summary to a file for easier downstream parsing without printing anything new to the console.

---


I implemented this with a new `NFTestReport` class. I tried to keep it as modular and distinct as possible from the existing logic, so the main structural changes are:

* There is a new `TestResult` enumeration defined in `common.py`.
* `NFTestCase`s now have a `status` attribute that is initialized to `TestResult.PENDING`. `NFTestCase.test()` sets that to `PASSED`, `FAILED`, `ERRORED`, or `SKIPPED` as appropriate.
* `NFTestRunner.main()` creates an `NFTestReport` instance, and uses `report.track_case(case)` as a context manager around each test case. If `--report` was passed it writes out that report after all the tests have completed.

Along the way I found a hidden bug where `common.resolve_single_path()` raised `ValueError`s, which were _not_ being caught by `NFTestRunner.main()`. That meant that NFTest would crash on the first `NFTestAssert` with 0 or 2+ matching files. I fixed that by:

* Moving `resolve_single_path` into `NFTestAssert`
* Updating `NFTestAssert` to throw custom exception classes derived from `NFTestAssertionError`, rather than `ValueError` and `AssertionError`.
* Updating `NFTestRunner.main()` to catch `NFTestAssertionError` rather than `AssertionError`.

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [x] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.


- [x] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.