### PR TITLE
Add release management workflows

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/alias-release.yaml
+++ b/.github/workflows/alias-release.yaml
@@ -1,0 +1,19 @@
+---
+name: 🛠️ Update release alias tags
+
+run-name: Update alias for ${{ github.event.action }} ${{ github.event.release.name }}
+
+on:
+  release:
+    types:
+      - published
+      - deleted
+
+permissions:
+  actions: read
+  contents: write
+
+jobs:
+  update-alias:
+    uses: uclahs-cds/tool-create-release/.github/workflows/wf-alias-release.yaml@v1
+    secrets: inherit

--- a/.github/workflows/finalize-release.yaml
+++ b/.github/workflows/finalize-release.yaml
@@ -1,0 +1,24 @@
+---
+name: 🛠️ Finalize release
+
+run-name: Finalize release from branch `${{ github.event.pull_request.head.ref }}`
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+permissions:
+  actions: read
+  contents: write
+  pull-requests: write
+
+jobs:
+  finalize-release:
+    if: ${{ github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'automation-create-release') }}
+    uses: uclahs-cds/tool-create-release/.github/workflows/wf-finalize-release.yaml@v1
+    secrets: inherit
+    with:
+      draft: false

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -1,0 +1,32 @@
+---
+name: 📦 Prepare new release
+
+run-name: Open PR for new ${{ inputs.bump_type }} release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        type: choice
+        description: Semantic version bump type
+        required: true
+        options:
+          - major
+          - minor
+          - patch
+      prerelease:
+        type: boolean
+        description: Create a prerelease
+
+permissions:
+  actions: read
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare-release:
+    uses: uclahs-cds/tool-create-release/.github/workflows/wf-prepare-release.yaml@v1
+    with:
+      bump_type: ${{ inputs.bump_type }}
+      prerelease: ${{ inputs.prerelease }}
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # NFTest
 
+[![GitHub release](https://img.shields.io/github/v/release/uclahs-cds/tool-NFTest)](https://github.com/uclahs-cds/tool-NFTest/actions/workflows/prepare-release.yaml)
+
 - [Overview](#overview)
 - [Installation](#installation)
     - [From GitHub](#install-directly-from-github)


### PR DESCRIPTION
This PR adds in the release management workflows from the newly-public https://github.com/uclahs-cds/tool-create-release.

Additionally, this cleans up several related issues:

* Enables Dependabot for GitHub Actions to keep them up-to-date
* Adds a helpful badge to the top of the README that links to the release creation workflow
