### PR TITLE
Fix hatch-vcs by ignoring alias tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Prevent hatch-vcs from picking up major version alias tags
+
 ## [1.2.0] - 2024-11-19
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,11 +20,11 @@ dependencies = [
     "PyYAML",
     "python-dotenv",
     "pytest",
-    "mock"
+    "mock<=5.1.0"
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "mock"]
+dev = ["pytest", "mock<=5.1.0"]
 
 [project.scripts]
 nftest = "nftest.__main__:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ package-data = { "nftest" = ["data/*"] }
 [tool.hatch.version]
 source = "vcs"
 
+[tool.hatch.version.raw-options]
+git_describe_command = "git describe --dirty --tags --long --match 'v[0-9]*.[0-9]*.[0-9]*'"
+
 [tool.hatch.build.hooks.vcs]
 version-file = "nftest/_version.py"
 


### PR DESCRIPTION
# Description

This is an irritating one. Despite #75 establishing dynamic versioning, I discovered today that version 1.2.0 always reports itself as version 1. This is because hatch-vcs defers to setuptools-scm, which has a [default `git describe` command](https://setuptools-scm.readthedocs.io/en/latest/config/#setuptools_scm.git.DEFAULT_DESCRIBE) of `git describe --dirty --tags --match *[0-9]*`.

Combine that with the aliasing workflows from #72, and the fact that `v1` [lexicographically](https://git-scm.com/docs/git-tag#Documentation/git-tag.txt---sortltkeygt) sorts before `v1.2.0`, and you ensure that the latest version will always identify itself with only the major version on install.

The fix is to use hatch-vcs's [`raw-options`](https://github.com/ofek/hatch-vcs?tab=readme-ov-file#version-source-options) to pass along an alternative `git_describe_command` to setuptools-scm to ensure that we only match against semver tags.

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [x] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.


- [x] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

